### PR TITLE
feat: track Bybandle results

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import * as Globle from './games/globle.js';
 import * as Bullpen from './games/bullpen.js';
 import * as FoodGuessr from './games/foodguessr.js';
 import * as TimeGuessr from './games/timeguessr.js';
+import * as Bybandle from './games/bybandle.js';
 import { GameEntry, GameEntryModel } from './core/database/schema.js';
 import fs from 'node:fs';
 import { generate_weekly_chart } from './charts/weekly_chart.js';
@@ -87,6 +88,13 @@ const response_message = new GameSummaryMessage({
       description: TimeGuessr.Description,
       fields: [
         { game: TimeGuessr.TimeGuessr, inline: true },
+      ]
+    },
+    {
+      title: 'Bybandle',
+      description: Bybandle.Description,
+      fields: [
+        { game: Bybandle.Bybandle, inline: true },
       ]
     }
 

--- a/src/games/bybandle.ts
+++ b/src/games/bybandle.ts
@@ -1,0 +1,19 @@
+import { GameBuilder } from '../core/builders/game_builder.js';
+import { MatchType } from '../core/message_parser.js';
+
+export const Bybandle = new GameBuilder('Bybandle')
+  .set_matcher(/Bybandle (\d{4}-\d{2}-\d{2}) ([\dX]\/\d)/, [
+    MatchType.Day,
+    MatchType.Score,
+  ])
+  .set_responder((entry) => {
+    const user = entry.user.server_name ?? entry.user.name;
+    if (entry.score.startsWith('X')) {
+      return `${user} did not recognize the Bybandle jingle for ${entry.day_id}`;
+    }
+    return `${user} scored ${entry.score} on Bybandle ${entry.day_id}`;
+  })
+  .build();
+
+export const Description: string = `Guess today's Bergen light rail jingle:
+[Bybandle](https://bybandle-production.up.railway.app)`;


### PR DESCRIPTION
## What

Adds [Bybandle](https://bybandle-production.up.railway.app) — a daily Bergen light rail jingle guessing game — as a tracked game.

Share text looks like this:

```
Bybandle 2026-07-27 2/3
🟠—🟢—⚪
```

The day (`2026-07-27`) and score (`2/3`) are parsed off the first line; the emoji travel line is ignored. `X/3` means the jingle was never guessed.

## Notes

- Score is stored as `n/3` like Wordle, so the default sorter puts `X/3` last and fewer guesses first.
- The game gets its own embed section, registered in `src/app.ts`.

## Testing

- `npx tsc --noEmit` reports no new errors (the two pre-existing ones in `src/app.ts` and `src/callbacks.ts` are untouched).
- Regex checked against real share strings for wins, losses and a Wordle message (no false match).
- Not run against a live Discord server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)