### PR TITLE
feat(4x3): add support for 4x3 by Hank Green

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import * as Bullpen from './games/bullpen.js';
 import * as FoodGuessr from './games/foodguessr.js';
 import * as TimeGuessr from './games/timeguessr.js';
 import * as Bybandle from './games/bybandle.js';
+import * as FourByThree from './games/fourbythree.js';
 import { GameEntry, GameEntryModel } from './core/database/schema.js';
 import fs from 'node:fs';
 import { generate_weekly_chart } from './charts/weekly_chart.js';
@@ -95,6 +96,13 @@ const response_message = new GameSummaryMessage({
       description: Bybandle.Description,
       fields: [
         { game: Bybandle.Bybandle, inline: true },
+      ]
+    },
+    {
+      title: '4x3',
+      description: FourByThree.Description,
+      fields: [
+        { game: FourByThree.FourByThree, inline: true },
       ]
     }
 

--- a/src/games/fourbythree.ts
+++ b/src/games/fourbythree.ts
@@ -1,0 +1,108 @@
+import { GameBuilder } from '../core/builders/game_builder.js';
+import { ScoreSorter } from '../core/embeds/embed_formatter.js';
+import { MatchType, MessageParser } from '../core/message_parser.js';
+
+/**
+ * Shared 4x3 results look like this:
+ *
+ * ```
+ * 27 July 2026
+ * 121 points • 1 mistake
+ * 🌟🟦🟦
+ * 🟨🟪🌟
+ * 🟨🌟🟨
+ * 🟩🌟🟩
+ * 🟪🌟🟪
+ * https://4x3.fun
+ * ```
+ *
+ * The first line is the puzzle date, localized by the browser the score was shared from. The
+ * summary line holds the point total, or `Out of guesses` when the puzzle was not solved, followed
+ * by `No mistakes`, `<n> mistake(s)` or `RULE BREAKER 💀` (letting the shared word go last every
+ * guess, which is worth -100 points). Every following row is one guess of three words, where 🌟 is
+ * the word shared by all four categories.
+ */
+const REGEX_4X3 =
+  /^(.+)\n((?:-?\d+ points|Out of guesses) • (?:\d+ mistakes?|No mistakes|RULE BREAKER 💀))\n(?:[🌟🟦🟩🟨⬜🟪]{3}\n)+https:\/\/4x3\.fun/mu;
+
+/** Score of a puzzle that was not solved. 4x3 only awards points for a solve. */
+const NO_POINTS = 'X';
+
+/** Mistake count of a rule breaker result, which does not share how many mistakes were made. */
+const RULE_BREAKER = 'RULE BREAKER';
+
+/**
+ * Normalizes the localized puzzle date to `YYYY-MM-DD`. Dates in a locale we cannot parse fall back
+ * to today, as a shared result is virtually always today's puzzle.
+ */
+const parse_day_id = (date: string): string => {
+  const parsed = new Date(date);
+  const day = isNaN(parsed.valueOf()) ? new Date() : parsed;
+
+  return [
+    day.getFullYear(),
+    String(day.getMonth() + 1).padStart(2, '0'),
+    String(day.getDate()).padStart(2, '0'),
+  ].join('-');
+};
+
+/**
+ * Turns the summary line into a `<points>,<mistakes>` score, e.g. `121,1`.
+ */
+const parse_score = (summary: string): string => {
+  const [points, mistakes] = summary.split(' • ');
+
+  return [
+    points === 'Out of guesses' ? NO_POINTS : points.replace(' points', ''),
+    mistakes.startsWith(RULE_BREAKER)
+      ? RULE_BREAKER
+      : mistakes === 'No mistakes'
+        ? '0'
+        : parseInt(mistakes).toString(),
+  ].join(',');
+};
+
+const points_of = (score: string): string => score.split(',')[0];
+const mistakes_of = (score: string): string => score.split(',')[1];
+
+/** Sorts on points, descending, with unsolved puzzles last. */
+const SCORE_SORTER: ScoreSorter = (a, b) => {
+  const x = parseInt(a.score);
+  const y = parseInt(b.score);
+  return isNaN(x) ? 1 : isNaN(y) ? -1 : y - x;
+};
+
+export const FourByThree = new GameBuilder('4x3')
+  .add_message_parser(
+    new MessageParser(
+      '4x3',
+      REGEX_4X3,
+      [MatchType.Day, MatchType.Score],
+      parse_day_id,
+      parse_score,
+    ),
+  )
+  .set_score_sorter(SCORE_SORTER)
+  .set_responder((entry) => {
+    const user = entry.user.server_name ?? entry.user.name;
+    const points = points_of(entry.score);
+    const mistakes = mistakes_of(entry.score);
+
+    if (mistakes === RULE_BREAKER) {
+      return `${user} broke the rules on 4x3 ${entry.day_id}, scoring ${points} points 💀`;
+    }
+    if (points === NO_POINTS) {
+      return `${user} ran out of guesses on 4x3 ${entry.day_id} after ${mistakes} mistakes`;
+    }
+    if (mistakes === '0') {
+      return `⭐ ${user} got ✨perfect✨ on 4x3 ${entry.day_id} with ${points} points ⭐`;
+    }
+    return `${user} did 4x3 ${entry.day_id} with ${points} points and ${mistakes} mistake${mistakes === '1' ? '' : 's'}`;
+  })
+  .set_embed_field_score_formatter(
+    (user_link, score) => `${user_link} : ${points_of(score)}`,
+  )
+  .build();
+
+export const Description: string = `Daily 4x3 puzzle by Hank Green:
+[Play 4x3](https://4x3.fun/)`;


### PR DESCRIPTION
Adds support for [4x3](https://4x3.fun/) by Hank Green — a daily puzzle where nine words split into four categories of three, and one shared word belongs to all four.

Shared results look like this:

```
27 July 2026
121 points • 1 mistake
🌟🟦🟦
🟨🟪🌟
🟨🌟🟨
🟩🌟🟩
🟪🌟🟪
https://4x3.fun/
```

### Notes

- **Points, not guesses**, so the game sorts descending. Unsolved puzzles share `Out of guesses` instead of a point total and are stored as score `X` so they sort last.
- **Score is stored as `<points>,<mistakes>`** (e.g. `121,1`) since the response message needs both. Letting the shared word go last every guess is a "RULE BREAKER" result worth -100 points that shares no mistake count, stored as `-100,RULE BREAKER`.
- **No puzzle number** — the first line is the puzzle date, formatted by `toLocaleDateString` in whichever browser shared it. Normalized to `YYYY-MM-DD` where parseable (`27 July 2026` and `July 27, 2026` both work), falling back to today otherwise. Results without a date line are custom/beta puzzles rather than the daily, and are not matched.

### Verified against

| message | day_id | score | response |
| --- | --- | --- | --- |
| solve, 1 mistake | `2026-07-27` | `121,1` | `jorgen did 4x3 2026-07-27 with 121 points and 1 mistake` |
| solve, no mistakes | `2026-07-27` | `160,0` | `⭐ jorgen got ✨perfect✨ on 4x3 2026-07-27 with 160 points ⭐` |
| out of guesses | `2026-07-27` | `X,3` | `jorgen ran out of guesses on 4x3 2026-07-27 after 3 mistakes` |
| rule breaker | `2026-07-27` | `-100,RULE BREAKER` | `jorgen broke the rules on 4x3 2026-07-27, scoring -100 points 💀` |

Other games' results and a bare `https://4x3.fun` link are correctly rejected. `npx tsc --noEmit` reports no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
