### PR TITLE
feat(summary): post the summary from a button instead of a reaction

### DIFF
--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -1,9 +1,5 @@
 import {
   Message,
-  MessageReaction,
-  PartialMessageReaction,
-  User,
-  PartialUser,
   Client,
   Events,
   CacheType,
@@ -13,6 +9,7 @@ import Config from './config.js';
 import { SlashCommand } from './core/command.js';
 import { GameSummaryMessage } from './core/embeds/embed_structure.js';
 import Game from './core/game.js';
+import { SUMMARY_BUTTON_ID } from './core/summary_button.js';
 
 /**
  * Checks whether a message is valid.
@@ -28,40 +25,6 @@ function message_is_valid(message: Message): boolean {
     !message.author.bot &&
     message.content.length <= 500
   );
-}
-
-/**
- * Checks whether a message reaction is valid.
- *
- * Checks whether the message reaction is:
- * - in an enabled channel,
- * - not added by a bot user,
- * - that the last message in the channel was not a Game Summary message.
- *
- * The rationale for blocking reaction events if the last message was a summary message
- * is that the only reason we handle reaction events is to post said message.
- * We don't want to spam a channel with messages if we can avoid it.
- *
- * related TODO: maybe add a slash-command that posts the summary.
- */
-function message_reaction_is_valid(
-  message_reaction: MessageReaction | PartialMessageReaction,
-  user: User | PartialUser,
-): boolean {
-  const last_message = message_reaction.message.channel.messages?.cache?.last();
-
-  // Reaction is in enabled channel
-  const channel_is_enabled = Config.ENABLED_CHANNEL_IDS.includes(
-    message_reaction.message.channel.id,
-  );
-
-  // If the last message posted was posted by this bot and contains embeds, it's probably the Game
-  // Summary message.
-  const last_message_was_game_summary =
-    last_message?.author.id === message_reaction.client.user.id &&
-    last_message.embeds.length > 0;
-
-  return !user.bot && channel_is_enabled && !last_message_was_game_summary;
 }
 
 /**
@@ -100,39 +63,38 @@ function generate_message_event_callback(
 }
 
 /**
- * Generates a callback function that validates message reactions and sends a game summary
- * response.
+ * Generates a callback function that handles interaction events.
  *
- * @param game_summary_message The game summary message to send.
+ * Handles two kinds of interaction:
+ * - presses of the game summary button, which is attached to every game response, and
+ * - application slash commands, if any were registered.
+ *
+ * @param game_summary_message The game summary message to send when the summary button is pressed.
+ * @param commands The slash commands to handle.
  */
-function generate_message_reaction_event_callback(
+function generate_interaction_event_callback(
   game_summary_message: GameSummaryMessage,
-): (
-  message_reaction: MessageReaction | PartialMessageReaction,
-  user: User | PartialUser,
-) => Promise<void> {
-  return async (message_reaction, user) => {
-    if (message_reaction_is_valid(message_reaction, user)) {
-      console.info('Valid reaction found, sending summary message.');
-      await game_summary_message.send(message_reaction).catch((err) => {
+  commands?: SlashCommand[],
+): (interaction: Interaction<CacheType>) => Promise<void> {
+  return async (interaction) => {
+    if (interaction.isButton()) {
+      if (
+        interaction.customId !== SUMMARY_BUTTON_ID ||
+        !Config.ENABLED_CHANNEL_IDS.includes(interaction.channelId)
+      ) {
+        return;
+      }
+
+      console.info('Summary button pressed, sending summary message.');
+      await game_summary_message.send(interaction).catch((err) => {
         console.error(
           `Something went wrong while sending game summary message: ${err}`,
         );
       });
+      return;
     }
-  };
-}
 
-/**
- * Generates a callback function that handles interaction events.
- *
- * @param commands The interactions to handle.
- */
-function generate_interaction_event_callback(
-  commands: SlashCommand[],
-): (interaction: Interaction<CacheType>) => Promise<void> {
-  return async (interaction) => {
-    if (!interaction.isChatInputCommand()) return;
+    if (!interaction.isChatInputCommand() || commands === undefined) return;
 
     await Promise.all(
       commands.map((command) =>
@@ -158,8 +120,8 @@ function generate_interaction_event_callback(
 }
 
 /**
- * Registers Discord callbacks for posted messages and message reactions, as well as
- * slash command handlers - if applicable.
+ * Registers Discord callbacks for posted messages and interactions - the latter covering both the
+ * game summary button and slash command handlers, if applicable.
  *
  * @param {Client} client - The Discord client.
  * @param {GameSummaryMessage} game_summary_message - Game summary message to register.
@@ -181,18 +143,16 @@ export function register_client_callbacks(
   console.info(`Registered callbacks for: ${game_names}.`);
 
   client.on(
-    Events.MessageReactionAdd,
-    generate_message_reaction_event_callback(game_summary_message),
+    Events.InteractionCreate,
+    generate_interaction_event_callback(game_summary_message, commands),
   );
-  console.info(`Registered message reaction callback.`);
-
-  if (commands !== undefined) {
-    client.on(
-      Events.InteractionCreate,
-      generate_interaction_event_callback(commands),
-    );
-    console.info(`Registered ${commands.length} application command handlers.`);
-  }
+  console.info(
+    `Registered interaction callback for the summary button${
+      commands !== undefined
+        ? ` and ${commands.length} application command handlers`
+        : ''
+    }.`,
+  );
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,10 +24,8 @@ const CLIENT_PARTIALS: Partials[] = [Partials.Message, Partials.Channel];
  */
 const CLIENT_INTENTS: GatewayIntentBits[] = [
   GatewayIntentBits.DirectMessages,
-  GatewayIntentBits.DirectMessageReactions,
   GatewayIntentBits.MessageContent,
   GatewayIntentBits.GuildMessages,
-  GatewayIntentBits.GuildMessageReactions,
   GatewayIntentBits.Guilds,
 ];
 

--- a/src/core/database/schema.ts
+++ b/src/core/database/schema.ts
@@ -37,3 +37,29 @@ const schema = new Schema<GameEntry, Model<GameEntry>>(
 );
 
 export const GameEntryModel = model('GameEntry', schema);
+
+/**
+ * The most recent game summary message the bot posted in a channel.
+ *
+ * Tracked so that posting a new summary can clean up the one it replaces.
+ */
+export interface SummaryMessage {
+  channel_id: Snowflake;
+  message_id: Snowflake;
+}
+
+const summary_message_schema = new Schema<
+  SummaryMessage,
+  Model<SummaryMessage>
+>(
+  {
+    channel_id: { type: String, required: true, unique: true },
+    message_id: { type: String, required: true },
+  },
+  { timestamps: true },
+);
+
+export const SummaryMessageModel = model(
+  'SummaryMessage',
+  summary_message_schema,
+);

--- a/src/core/embeds/embed_structure.ts
+++ b/src/core/embeds/embed_structure.ts
@@ -1,12 +1,13 @@
 import {
   APIEmbed,
   APIEmbedField,
+  ButtonInteraction,
   EmbedBuilder,
-  MessageReaction,
-  PartialMessageReaction,
-  TextChannel,
+  Snowflake,
 } from 'discord.js';
 import Game from '../game.js';
+import { SummaryMessage, SummaryMessageModel } from '../database/schema.js';
+import { get_today } from '../../util.js';
 import { EmbedMessage } from './embed_types.js';
 
 
@@ -26,12 +27,17 @@ export class GameSummaryMessage {
   }
 
   /**
-   * Sends the game summary message to the given message reaction's channel.
+   * Sends the game summary message as a reply to the given button interaction, then deletes the
+   * summary message it replaces - see `delete_replaced_summary`.
    *
-   * @param {MessageReaction | PartialMessageReaction} message_reaction - Message reaction in the channel to send to.
+   * The interaction is deferred before anything else, because building the summary hits the
+   * database and Discord discards interactions that are not acknowledged within three seconds.
+   *
+   * @param {ButtonInteraction} interaction - The button interaction to reply to.
    */
-  async send(message_reaction: MessageReaction | PartialMessageReaction) {
-    const message = message_reaction.message;
+  async send(interaction: ButtonInteraction) {
+    await interaction.deferReply();
+
     const payload = {
       content:
         typeof this.message.content === 'string'
@@ -39,14 +45,61 @@ export class GameSummaryMessage {
           : this.message.content(),
       embeds: await this.get_embeds(),
     };
-    await (message.channel as TextChannel)
-      .send(payload)
-      .then(() =>
-        console.log(
-          `Sent reaction message to ${message.member?.displayName ?? message.author!.displayName}.`,
+    const summary = await interaction.editReply(payload);
+    console.log(
+      `Sent summary message to ${interaction.member?.user.username ?? interaction.user.username}.`,
+    );
+
+    // Only once the new summary is up do we clear away the one it replaces.
+    const replaced = await GameSummaryMessage.track_summary(
+      interaction.channelId,
+      summary.id,
+    );
+    await GameSummaryMessage.delete_replaced_summary(interaction, replaced);
+  }
+
+  /**
+   * Records `message_id` as the current summary message for `channel_id`, and returns the entry it
+   * replaced - if any.
+   *
+   * The swap is a single atomic update so that two people clicking the summary button at the same
+   * time cannot both claim, and both try to delete, the same previous summary.
+   */
+  private static async track_summary(
+    channel_id: Snowflake,
+    message_id: Snowflake,
+  ): Promise<SummaryMessage | null> {
+    return await SummaryMessageModel.findOneAndUpdate(
+      { channel_id: channel_id },
+      { channel_id: channel_id, message_id: message_id },
+      { upsert: true },
+    ).exec();
+  }
+
+  /**
+   * Deletes a summary message that has been replaced by a newer one, keeping a single summary per
+   * channel per day.
+   *
+   * Summaries from previous days are left alone - those are a record of that day. Failing to
+   * delete is not treated as an error: the message may well be gone already.
+   */
+  private static async delete_replaced_summary(
+    interaction: ButtonInteraction,
+    replaced: SummaryMessage | null,
+  ) {
+    const updated_at = (replaced as { updatedAt?: Date } | null)?.updatedAt;
+    if (!replaced || !updated_at || updated_at < get_today()) {
+      return;
+    }
+
+    await interaction.channel?.messages
+      .fetch(replaced.message_id)
+      .then((message) => message.delete())
+      .catch((err) =>
+        console.info(
+          `Could not delete replaced summary message ${replaced.message_id}: ${err}`,
         ),
-      )
-      .catch((err) => console.warn(`Could not send reaction message: ${err}`));
+      );
   }
 
   /**
@@ -71,6 +124,12 @@ export class GameSummaryMessage {
         if (field !== null) {
           fields.push(field);
         }
+      }
+
+      // Only include collections someone has played today. Games with no entries produce no
+      // field, so an empty field list means nobody played anything in this collection.
+      if (fields.length === 0) {
+        continue;
       }
 
       const footer_options = embed_structure.footer

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -2,6 +2,7 @@ import { EmbedField, Message, TextChannel } from 'discord.js';
 import { MessageParser } from './message_parser.js';
 import { GameEntry, GameEntryModel } from './database/schema.js';
 import { EmbedFieldFormatter } from './embeds/embed_formatter.js';
+import { summary_button_row } from './summary_button.js';
 import { get_today } from '../util.js';
 
 export interface Responder {
@@ -84,8 +85,10 @@ export class Game {
   }
 
   private static async send_response(message: Message, content: string) {
-    const sent_message = await (message.channel as TextChannel).send(content);
-    await sent_message.react('📋');
+    await (message.channel as TextChannel).send({
+      content,
+      components: [summary_button_row()],
+    });
   }
 
   /**

--- a/src/core/summary_button.ts
+++ b/src/core/summary_button.ts
@@ -1,0 +1,25 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+/**
+ * Custom ID of the button that posts the game summary message.
+ *
+ * Custom IDs are namespaced as `dailydle:<action>` so that interaction callbacks can tell our
+ * components apart from anything else that might end up on a message.
+ */
+export const SUMMARY_BUTTON_ID = 'dailydle:summary';
+
+/**
+ * Builds the action row holding the game summary button.
+ *
+ * This is attached to the response the bot posts for every registered game entry, and is what
+ * lets a user ask for the game summary message.
+ */
+export function summary_button_row(): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(SUMMARY_BUTTON_ID)
+      .setLabel('Show summary')
+      .setEmoji('📋')
+      .setStyle(ButtonStyle.Primary),
+  );
+}


### PR DESCRIPTION
Reacting to a message in an enabled channel posted the game summary, without checking which emoji
was used or which message was reacted to. A button on the bot's game response does it instead.

Closes #63

- Game responses carry a `Show summary` button instead of a 📋 reaction.
- `InteractionCreate` routes the button alongside slash commands; the reaction callback is gone.
- A new summary deletes the one it replaces, so the channel keeps one summary per day. Summaries
  from previous days are left alone.
- The scoreboard only lists collections played today — unplayed ones rendered as a bare title and
  description (9 embeds down to 1 below).
- Dropped the now-unused `GuildMessageReactions` and `DirectMessageReactions` intents.

## Screenshot

<img width="529" height="572" alt="image" src="https://github.com/user-attachments/assets/d36b9467-1ee5-4e60-baa3-ef490f19d979" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
