### PR TITLE
feat(summary): render ranked scoreboards fitted to each game

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+/**
+ * The project is native ESM ("type": "module" with NodeNext resolution), so jest needs the ts-jest
+ * ESM preset and node's experimental VM modules flag - see the `test` script in package.json.
+ */
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  // Source imports end in `.js` per NodeNext; point jest back at the `.ts` sources.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { useESM: true }],
+  },
+  testMatch: ['**/src/test/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "build": "tsc",
     "start": "node --loader ts-node/esm .\\src\\app.ts",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,9 +21,12 @@ import { generate_mock_data } from './test/generate_mock_data.js';
 // #region Constants
 
 const response_message_content = () =>
-  `**Dailydle** - ${new Date().toLocaleDateString('en-GB', { weekday: 'long', month: 'long', day: 'numeric' })}
-  
-Share your dailydle scores in this channel to register your entry`;
+  `## 📋 Dailydle
+### ${new Date().toLocaleDateString('en-GB', { weekday: 'long', month: 'long', day: 'numeric' })}
+-# Share your dailydle scores in this channel to register your entry`;
+
+const no_scores_content =
+  '*Nothing registered yet today - be the first.*';
 
 const enable_dev_features = process.argv.includes('--dev')
 if (enable_dev_features) {
@@ -32,10 +35,12 @@ if (enable_dev_features) {
 
 const response_message = new GameSummaryMessage({
   content: response_message_content,
+  empty: no_scores_content,
   embeds: [
     {
-      title: 'New York Times',
+      title: '📰 New York Times',
       description: NYT.Description,
+      color: NYT.Color,
       fields: [
         { game: NYT.Wordle, inline: true },
         { game: NYT.Connections, inline: true },
@@ -44,32 +49,36 @@ const response_message = new GameSummaryMessage({
       ],
     },
     {
-      title: 'Bullpen',
+      title: '⚾ Bullpen',
       description: Bullpen.Description,
+      color: Bullpen.Color,
       fields: [
         { game: Bullpen.BullpenEasy, inline: true },
         { game: Bullpen.BullpenHard, inline: true },
       ]
     },
     {
-      title: 'NRK',
+      title: '📺 NRK',
       description: NRK.Description,
+      color: NRK.Color,
       fields: [
         { game: NRK.Tvers, inline: true },
         { game: NRK.Former, inline: true },
       ]
     },
     {
-      title: 'Globle',
+      title: '🌍 Globle',
       description: Globle.Description,
+      color: Globle.Color,
       fields: [
         { game: Globle.Globle, inline: true },
         { game: Globle.GlobleCapitals, inline: true },
       ]
     },
     {
-      title: 'Gamedle',
+      title: '🎮 Gamedle',
       description: Gamedle.Description,
+      color: Gamedle.Color,
       fields: [
         { game: Gamedle.Classic, inline: true },
         { game: Gamedle.Artwork, inline: true },
@@ -78,29 +87,33 @@ const response_message = new GameSummaryMessage({
       ],
     },
     {
-      title: 'FoodGuessr',
+      title: '🍽️ FoodGuessr',
       description: FoodGuessr.Description,
+      color: FoodGuessr.Color,
       fields: [
         { game: FoodGuessr.FoodGuessr, inline: true },
       ],
     },
     {
-      title: 'TimeGuessr',
+      title: '🕰️ TimeGuessr',
       description: TimeGuessr.Description,
+      color: TimeGuessr.Color,
       fields: [
         { game: TimeGuessr.TimeGuessr, inline: true },
       ]
     },
     {
-      title: 'Bybandle',
+      title: '🚋 Bybandle',
       description: Bybandle.Description,
+      color: Bybandle.Color,
       fields: [
         { game: Bybandle.Bybandle, inline: true },
       ]
     },
     {
-      title: '4x3',
+      title: '🌟 4x3',
       description: FourByThree.Description,
+      color: FourByThree.Color,
       fields: [
         { game: FourByThree.FourByThree, inline: true },
       ]

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,8 +25,7 @@ const response_message_content = () =>
 ### ${new Date().toLocaleDateString('en-GB', { weekday: 'long', month: 'long', day: 'numeric' })}
 -# Share your dailydle scores in this channel to register your entry`;
 
-const no_scores_content =
-  '*Nothing registered yet today - be the first.*';
+const no_scores_content = '*Nothing registered yet today - be the first.*';
 
 const enable_dev_features = process.argv.includes('--dev')
 if (enable_dev_features) {

--- a/src/core/builders/game_builder.ts
+++ b/src/core/builders/game_builder.ts
@@ -83,28 +83,19 @@ export class GameBuilder {
     return this;
   }
 
-  /**
-   * Sets how this game's scores are presented on the summary scoreboard - its heading, what the
-   * score measures, and how a stored score is rendered.
-   */
+  /** Sets how this game's scores are presented on the summary scoreboard. */
   set_scoreboard(scoreboard: ScoreboardStyle): GameBuilder {
     this.scoreboard = scoreboard;
     return this;
   }
 
-  /**
-   * Sets the score sorter used for ranking this game's scoreboard.
-   *
-   * Defaults to `lowest_first`, so games where a higher score wins have to say so.
-   */
+  /** Defaults to `lowest_first`, so games where a higher score wins have to say so. */
   set_score_sorter(score_sorter: ScoreSorter): GameBuilder {
     this.score_sorter = score_sorter;
     return this;
   }
 
-  /**
-   * Sets the maximum game entries shown on this game's scoreboard.
-   */
+  /** Sets the maximum game entries shown on this game's scoreboard. */
   set_max_embed_field_entries(max_entries: number): GameBuilder {
     this.max_entries = max_entries;
     return this;

--- a/src/core/builders/game_builder.ts
+++ b/src/core/builders/game_builder.ts
@@ -1,8 +1,5 @@
-import {
-  EmbedFieldFormatter,
-  ScoreFormatter,
-  ScoreSorter,
-} from '../embeds/embed_formatter.js';
+import { EmbedFieldFormatter } from '../embeds/embed_formatter.js';
+import { ScoreboardStyle, ScoreSorter } from '../embeds/scoreboard.js';
 import { Game, Responder } from '../game.js';
 import { MatchParser, MatchType, MessageParser } from '../message_parser.js';
 
@@ -18,9 +15,8 @@ export class GameBuilder {
   private day_id_parser?: MatchParser;
   private score_parser?: MatchParser;
 
-  private formatter?: EmbedFieldFormatter;
+  private scoreboard?: ScoreboardStyle;
   private score_sorter?: ScoreSorter;
-  private score_formatter?: ScoreFormatter;
   private max_entries?: number;
 
   private responder?: Responder;
@@ -88,15 +84,18 @@ export class GameBuilder {
   }
 
   /**
-   * Sets the `EmbedFieldFormatter` for this game.
+   * Sets how this game's scores are presented on the summary scoreboard - its heading, what the
+   * score measures, and how a stored score is rendered.
    */
-  set_formatter(formatter: EmbedFieldFormatter): GameBuilder {
-    this.formatter = formatter;
+  set_scoreboard(scoreboard: ScoreboardStyle): GameBuilder {
+    this.scoreboard = scoreboard;
     return this;
   }
 
   /**
-   * Sets the score sorter used for displaying high-scores in an embed field.
+   * Sets the score sorter used for ranking this game's scoreboard.
+   *
+   * Defaults to `lowest_first`, so games where a higher score wins have to say so.
    */
   set_score_sorter(score_sorter: ScoreSorter): GameBuilder {
     this.score_sorter = score_sorter;
@@ -104,17 +103,7 @@ export class GameBuilder {
   }
 
   /**
-   * Sets the formatter used for displaying a user and their score in the embed field.
-   */
-  set_embed_field_score_formatter(
-    score_formatter: ScoreFormatter,
-  ): GameBuilder {
-    this.score_formatter = score_formatter;
-    return this;
-  }
-
-  /**
-   * Sets the maximum game entries allowed for a embed field.
+   * Sets the maximum game entries shown on this game's scoreboard.
    */
   set_max_embed_field_entries(max_entries: number): GameBuilder {
     this.max_entries = max_entries;
@@ -179,17 +168,16 @@ export class GameBuilder {
   }
 
   private build_formatter(): EmbedFieldFormatter {
-    if (this.formatter !== undefined) {
-      return this.formatter;
-    }
-
-    if (this.name === undefined)
-      throw new Error('Game name must have a value.');
+    // Entries are stored under the name of the parser that matched them, not the name of the game,
+    // so the scoreboard has to look them up by every name this game's parsers produce.
+    const game_names = [
+      ...new Set(this.build_message_parsers().map((parser) => parser.name)),
+    ];
 
     return new EmbedFieldFormatter(
-      this.name,
+      game_names,
+      this.scoreboard,
       this.score_sorter,
-      this.score_formatter,
       this.max_entries,
     );
   }

--- a/src/core/database/schema.ts
+++ b/src/core/database/schema.ts
@@ -46,18 +46,10 @@ export const GameEntryModel = model('GameEntry', schema);
 export interface SummaryMessage {
   channel_id: Snowflake;
 
-  /**
-   * Every message the summary is made up of, in the order they were posted. A summary too big for
-   * one message is split across several, and all of them have to be cleaned up together.
-   */
+  /** Every message the summary is made up of, in the order they were posted. */
   message_ids: Snowflake[];
 
-  /**
-   * Summaries tracked before they could span more than one message.
-   *
-   * @deprecated Read only, so rows written by an older version can still be cleaned up. New rows
-   * use `message_ids`.
-   */
+  /** @deprecated Read only, so rows written by an older version can still be cleaned up. */
   message_id?: Snowflake;
 }
 

--- a/src/core/database/schema.ts
+++ b/src/core/database/schema.ts
@@ -14,7 +14,7 @@ export interface GameEntry {
   channel_id: Snowflake;
   server_id: Snowflake;
   content?: string;
-  schema_version: string
+  schema_version: string;
 }
 
 const schema = new Schema<GameEntry, Model<GameEntry>>(
@@ -31,7 +31,7 @@ const schema = new Schema<GameEntry, Model<GameEntry>>(
     channel_id: { type: String, required: true },
     server_id: { type: String, required: true },
     content: String,
-    schema_version: { type: String, default: "2" },
+    schema_version: { type: String, default: '2' },
   },
   { timestamps: true },
 );
@@ -39,13 +39,26 @@ const schema = new Schema<GameEntry, Model<GameEntry>>(
 export const GameEntryModel = model('GameEntry', schema);
 
 /**
- * The most recent game summary message the bot posted in a channel.
+ * The most recent game summary the bot posted in a channel.
  *
  * Tracked so that posting a new summary can clean up the one it replaces.
  */
 export interface SummaryMessage {
   channel_id: Snowflake;
-  message_id: Snowflake;
+
+  /**
+   * Every message the summary is made up of, in the order they were posted. A summary too big for
+   * one message is split across several, and all of them have to be cleaned up together.
+   */
+  message_ids: Snowflake[];
+
+  /**
+   * Summaries tracked before they could span more than one message.
+   *
+   * @deprecated Read only, so rows written by an older version can still be cleaned up. New rows
+   * use `message_ids`.
+   */
+  message_id?: Snowflake;
 }
 
 const summary_message_schema = new Schema<
@@ -54,7 +67,8 @@ const summary_message_schema = new Schema<
 >(
   {
     channel_id: { type: String, required: true, unique: true },
-    message_id: { type: String, required: true },
+    message_ids: { type: [String], default: [] },
+    message_id: { type: String },
   },
   { timestamps: true },
 );

--- a/src/core/embeds/embed_formatter.ts
+++ b/src/core/embeds/embed_formatter.ts
@@ -35,14 +35,14 @@ export interface ScoreboardLayout {
 }
 
 /**
- * Layouts to render the summary in, best first, falling through until one fits inside Discord's
- * embed budget.
+ * Layouts to render the summary in, best first, falling through until one fits in the messages the
+ * summary is allowed to span.
  *
- * A player's name links to the message they shared their score in, and that link is around five
- * sixths of a row's length. On a quiet day everything fits and nothing is given up; on a day where
- * every game was played by everybody, that much of the budget spent on links would leave room for a
- * podium of one. Deep scoreboards are worth more than clickable names, so the links go first, and
- * only then does the summary start showing fewer players.
+ * A summary too big for one message is split across several before any of this applies, so the
+ * first entry is what almost every day gets. These are for the day so busy that even splitting is
+ * not enough. A player's name links to the message they shared their score in, and that link is
+ * around five sixths of a row's length, so the links go first - deep scoreboards are worth more than
+ * clickable names - and only then does the summary start showing fewer players.
  */
 export const LAYOUT_PREFERENCES: ScoreboardLayout[] = [
   { rows: DEFAULT_MAX_ENTRIES, links: true },

--- a/src/core/embeds/embed_formatter.ts
+++ b/src/core/embeds/embed_formatter.ts
@@ -155,7 +155,7 @@ function render_value(rows: string[], total_entries: number): string {
   return (remainder > 0 ? [...rows, more_row(remainder)] : rows).join('\n');
 }
 
-/** `-#` is Discord's subtext markup, rendering this smaller and greyer than a real row. */
+/** Italic, not `-#` subtext - Discord does not render subtext inside embed fields. */
 function more_row(remainder: number): string {
-  return `-# + ${remainder} more`;
+  return `*+ ${remainder} more*`;
 }

--- a/src/core/embeds/embed_formatter.ts
+++ b/src/core/embeds/embed_formatter.ts
@@ -1,122 +1,240 @@
-import { EmbedField } from 'discord.js';
+import { APIEmbedField, Snowflake } from 'discord.js';
 import { GameEntry, GameEntryModel } from '../database/schema.js';
 import { get_today } from '../../util.js';
+import {
+  lowest_first,
+  render_heading,
+  render_rows,
+  ScoreboardStyle,
+  ScoreSorter,
+} from './scoreboard.js';
 
 /**
- * A function that sorts game entries.
+ * Discord's limit on the character count of a single embed field value.
  */
-export interface ScoreSorter {
-  (a: GameEntry, b: GameEntry): number;
+export const MAX_FIELD_VALUE_LENGTH = 1024;
+
+/**
+ * Rows to show on a scoreboard before the rest are summarized as `+ N more`.
+ */
+export const DEFAULT_MAX_ENTRIES = 10;
+
+/**
+ * How much of a scoreboard to render.
+ */
+export interface ScoreboardLayout {
+  /**
+   * Rows to show at most.
+   */
+  rows: number;
+
+  /**
+   * Whether names link to the message the score was shared in.
+   */
+  links: boolean;
 }
 
 /**
- * A function that formats a score for display in a message embed.
+ * Layouts to render the summary in, best first, falling through until one fits inside Discord's
+ * embed budget.
  *
- * @param {string} user_link - A username formatted with a link to their game entry message.
- * @param {string} score - Their score.
+ * A player's name links to the message they shared their score in, and that link is around five
+ * sixths of a row's length. On a quiet day everything fits and nothing is given up; on a day where
+ * every game was played by everybody, that much of the budget spent on links would leave room for a
+ * podium of one. Deep scoreboards are worth more than clickable names, so the links go first, and
+ * only then does the summary start showing fewer players.
  */
-export interface ScoreFormatter {
-  (user_link: string, score: string): string;
+export const LAYOUT_PREFERENCES: ScoreboardLayout[] = [
+  { rows: DEFAULT_MAX_ENTRIES, links: true },
+  { rows: 6, links: true },
+  { rows: 5, links: true },
+  { rows: DEFAULT_MAX_ENTRIES, links: false },
+  { rows: 6, links: false },
+  { rows: 5, links: false },
+  { rows: 3, links: false },
+  { rows: 1, links: false },
+];
+
+/**
+ * A rendered scoreboard, and what went into it.
+ */
+export interface ScoreboardField {
+  /**
+   * The scoreboard as an embed field.
+   */
+  field: APIEmbedField;
+
+  /**
+   * Discord user IDs of everyone with an entry on this scoreboard.
+   */
+  players: Snowflake[];
+
+  /**
+   * Number of entries on this scoreboard, counting any it had no room for.
+   */
+  entries: number;
 }
 
 /**
- * Default score sorter. Sorts in ascending order, with letters after numbers.
- */
-export const DEFAULT_SCORE_SORTER: ScoreSorter = (
-  a: GameEntry,
-  b: GameEntry,
-) => {
-  const x = parseInt(a.score);
-  const y = parseInt(b.score);
-  return isNaN(x) ? 1 : isNaN(y) ? -1 : x - y;
-};
-
-/**
- * Default score formatter. Returns `<user_link> : <score>`.
- */
-export const DEFAULT_SCORE_FORMATTER: ScoreFormatter = (
-  user_link: string,
-  score: string,
-) => `${user_link} : ${score}`;
-
-/**
- * Formatter responsible for generating an embed field for a game.
+ * Formatter responsible for turning a game's entries from today into a scoreboard.
  */
 export class EmbedFieldFormatter {
-  private name: string;
+  private game_names: string[];
+  private style: ScoreboardStyle;
   private score_sorter: ScoreSorter;
-  private score_formatter: ScoreFormatter;
-  private max_entries?: number;
+  private max_entries: number;
 
   /**
    * Initializes an `EmbedFieldFormatter`.
    *
-   * @param {string} name - The name of the game, used as the title of the embed field.
-   * @param {ScoreSorter} [score_sorter=DEFAULT_SCORE_SORTER] - Score sorting function for
-   * displaying top entries.
-   * @param {ScoreFormatter} [score_formatter=DEFAULT_SCORE_FORMATTER] - Score formatting function
-   * for displaying game entries.
-   * @param {number} [max_entries=5] - Optional. The maximum entries to show in the field, the
-   * remainder being displayed as `+N`.
+   * @param {string[]} game_names - Names entries for this game are stored under. A game can have
+   * more than one, as each of its message parsers names the entries it produces.
+   * @param {ScoreboardStyle} [style={}] - How this game's scores are presented.
+   * @param {ScoreSorter} [score_sorter=lowest_first()] - Ranks the entries, best result first.
+   * @param {number} [max_entries=DEFAULT_MAX_ENTRIES] - Rows to show before the remainder is
+   * summarized as `+ N more`.
    */
   constructor(
-    name: string,
-    score_sorter: ScoreSorter = DEFAULT_SCORE_SORTER,
-    score_formatter: ScoreFormatter = DEFAULT_SCORE_FORMATTER,
-    max_entries: number = 5,
+    game_names: string[],
+    style: ScoreboardStyle = {},
+    score_sorter: ScoreSorter = lowest_first(),
+    max_entries: number = DEFAULT_MAX_ENTRIES,
   ) {
-    this.name = name;
+    this.game_names = game_names;
+    this.style = style;
     this.score_sorter = score_sorter;
-    this.score_formatter = score_formatter;
     this.max_entries = max_entries;
   }
 
   /**
-   * Generates an embed field.
+   * Loads and ranks today's entries for this game.
    *
-   * @param {boolean} [inline=true] - Whether the embed field should be inline.
-   * @returns {Promise<EmbedField>} The embed field.
+   * Loading is separate from rendering so that the summary can see how much there is to show across
+   * every game before it decides how many rows each scoreboard gets - see `Scoreboard.render`.
+   *
+   * @returns {Promise<Scoreboard | null>} The scoreboard, or `null` if nobody played today.
    */
-  public async get_embed_field(
-    inline: boolean = true,
-  ): Promise<EmbedField | null> {
-    let entries = await GameEntryModel.find({
-      game: this.name,
+  public async load(): Promise<Scoreboard | null> {
+    const entries = await GameEntryModel.find({
+      game: { $in: this.game_names },
       createdAt: { $gte: get_today() },
     }).exec();
-    entries.sort(this.score_sorter);
-
-    // Handle max entries. If `max_entries` is set, slice the array and
-    // save the remainder so we can use it later to append a `+ N` to
-    // the end of the field.
-    let remainder = 0;
-    if (this.max_entries !== undefined) {
-      remainder = entries.length - this.max_entries;
-      entries = entries.slice(0, this.max_entries);
-    }
 
     if (entries.length === 0) {
       return null;
     }
 
-    let value = entries
-      .map((e) => {
-        const message_url = `https://discord.com/channels/${e.server_id}/${e.channel_id}/${e.message_id}`;
-        const user = `[${e.user.server_name ?? e.user.name}](${message_url})`;
-    
-        return this.score_formatter(user, e.score)
-      })
-      .join('\n');
+    return new Scoreboard(
+      render_heading(this.style, this.game_names[0]),
+      this.style,
+      [...entries].sort(this.score_sorter),
+      this.max_entries,
+    );
+  }
+}
 
-    // Add remainder if applicable
-    if (remainder > 0) {
-      value += `\n+ ${remainder}`;
+/**
+ * One game's ranked entries for today, ready to be rendered as an embed field.
+ */
+export class Scoreboard {
+  readonly heading: string;
+  readonly entries: GameEntry[];
+  private style: ScoreboardStyle;
+  private max_entries: number;
+
+  constructor(
+    heading: string,
+    style: ScoreboardStyle,
+    entries: GameEntry[],
+    max_entries: number,
+  ) {
+    this.heading = heading;
+    this.style = style;
+    this.entries = entries;
+    this.max_entries = max_entries;
+  }
+
+  /**
+   * Renders the scoreboard as an embed field.
+   *
+   * @param {boolean} inline - Whether the embed field should be inline.
+   * @param {ScoreboardLayout} layout - How much of the scoreboard to render.
+   * @param {number} budget - Characters the field value may take up.
+   * @returns {ScoreboardField | null} The field, or `null` if there was not room for even one row.
+   */
+  public render(
+    inline: boolean,
+    layout: ScoreboardLayout,
+    budget: number = MAX_FIELD_VALUE_LENGTH,
+  ): ScoreboardField | null {
+    const limit = Math.min(layout.rows, this.max_entries);
+    const rows = render_rows(
+      this.entries.slice(0, limit),
+      this.style,
+      layout.links,
+    );
+    const value = fit_rows(rows, this.entries.length, budget);
+
+    if (value === null) {
+      return null;
     }
 
     return {
-      name: this.name,
-      value: value,
-      inline: inline,
+      field: { name: this.heading, value: value, inline: inline },
+      players: this.players,
+      entries: this.entries.length,
     };
   }
+
+  /**
+   * Discord user IDs of everyone with an entry on this scoreboard.
+   */
+  public get players(): Snowflake[] {
+    return [...new Set(this.entries.map((entry) => entry.user.id))];
+  }
+}
+
+/**
+ * Joins as many rows as fit in `budget`, summarizing everything left over as `+ N more`.
+ *
+ * Rows carry a link per player, so a busy day can run a scoreboard past what Discord accepts in a
+ * field - and an embed Discord rejects means no summary at all. Trimming to fit keeps the top of
+ * the scoreboard, which is the part worth reading.
+ *
+ * @returns {string | null} The field value, or `null` if there was not even room for one row.
+ */
+function fit_rows(
+  rows: string[],
+  total_entries: number,
+  budget: number,
+): string | null {
+  const limit = Math.min(budget, MAX_FIELD_VALUE_LENGTH);
+  const shown: string[] = [];
+
+  for (const row of rows) {
+    if (render_value([...shown, row], total_entries).length > limit) {
+      break;
+    }
+    shown.push(row);
+  }
+
+  return shown.length === 0 ? null : render_value(shown, total_entries);
+}
+
+/**
+ * Joins rows into a field value, ending on a `+ N more` line if any entries are left out.
+ */
+function render_value(rows: string[], total_entries: number): string {
+  const remainder = total_entries - rows.length;
+
+  return (remainder > 0 ? [...rows, more_row(remainder)] : rows).join('\n');
+}
+
+/**
+ * Renders the line standing in for entries the scoreboard had no room for.
+ *
+ * `-#` is Discord's subtext markup, which renders this smaller and greyer than a real row.
+ */
+function more_row(remainder: number): string {
+  return `-# + ${remainder} more`;
 }

--- a/src/core/embeds/embed_formatter.ts
+++ b/src/core/embeds/embed_formatter.ts
@@ -9,75 +9,22 @@ import {
   ScoreSorter,
 } from './scoreboard.js';
 
-/**
- * Discord's limit on the character count of a single embed field value.
- */
+/** Discord's limit on the character count of a single embed field value. */
 export const MAX_FIELD_VALUE_LENGTH = 1024;
 
-/**
- * Rows to show on a scoreboard before the rest are summarized as `+ N more`.
- */
+/** Rows to show before the rest are summarized as `+ N more`. */
 export const DEFAULT_MAX_ENTRIES = 10;
 
-/**
- * How much of a scoreboard to render.
- */
-export interface ScoreboardLayout {
-  /**
-   * Rows to show at most.
-   */
-  rows: number;
-
-  /**
-   * Whether names link to the message the score was shared in.
-   */
-  links: boolean;
-}
-
-/**
- * Layouts to render the summary in, best first, falling through until one fits in the messages the
- * summary is allowed to span.
- *
- * A summary too big for one message is split across several before any of this applies, so the
- * first entry is what almost every day gets. These are for the day so busy that even splitting is
- * not enough. A player's name links to the message they shared their score in, and that link is
- * around five sixths of a row's length, so the links go first - deep scoreboards are worth more than
- * clickable names - and only then does the summary start showing fewer players.
- */
-export const LAYOUT_PREFERENCES: ScoreboardLayout[] = [
-  { rows: DEFAULT_MAX_ENTRIES, links: true },
-  { rows: 6, links: true },
-  { rows: 5, links: true },
-  { rows: DEFAULT_MAX_ENTRIES, links: false },
-  { rows: 6, links: false },
-  { rows: 5, links: false },
-  { rows: 3, links: false },
-  { rows: 1, links: false },
-];
-
-/**
- * A rendered scoreboard, and what went into it.
- */
+/** A rendered scoreboard, and what went into it. */
 export interface ScoreboardField {
-  /**
-   * The scoreboard as an embed field.
-   */
   field: APIEmbedField;
-
-  /**
-   * Discord user IDs of everyone with an entry on this scoreboard.
-   */
   players: Snowflake[];
 
-  /**
-   * Number of entries on this scoreboard, counting any it had no room for.
-   */
+  /** Entries on this scoreboard, counting any it had no room for. */
   entries: number;
 }
 
-/**
- * Formatter responsible for turning a game's entries from today into a scoreboard.
- */
+/** Turns a game's entries from today into a scoreboard. */
 export class EmbedFieldFormatter {
   private game_names: string[];
   private style: ScoreboardStyle;
@@ -109,9 +56,6 @@ export class EmbedFieldFormatter {
   /**
    * Loads and ranks today's entries for this game.
    *
-   * Loading is separate from rendering so that the summary can see how much there is to show across
-   * every game before it decides how many rows each scoreboard gets - see `Scoreboard.render`.
-   *
    * @returns {Promise<Scoreboard | null>} The scoreboard, or `null` if nobody played today.
    */
   public async load(): Promise<Scoreboard | null> {
@@ -133,9 +77,7 @@ export class EmbedFieldFormatter {
   }
 }
 
-/**
- * One game's ranked entries for today, ready to be rendered as an embed field.
- */
+/** One game's ranked entries for today, ready to be rendered as an embed field. */
 export class Scoreboard {
   readonly heading: string;
   readonly entries: GameEntry[];
@@ -158,22 +100,14 @@ export class Scoreboard {
    * Renders the scoreboard as an embed field.
    *
    * @param {boolean} inline - Whether the embed field should be inline.
-   * @param {ScoreboardLayout} layout - How much of the scoreboard to render.
-   * @param {number} budget - Characters the field value may take up.
    * @returns {ScoreboardField | null} The field, or `null` if there was not room for even one row.
    */
-  public render(
-    inline: boolean,
-    layout: ScoreboardLayout,
-    budget: number = MAX_FIELD_VALUE_LENGTH,
-  ): ScoreboardField | null {
-    const limit = Math.min(layout.rows, this.max_entries);
+  public render(inline: boolean): ScoreboardField | null {
     const rows = render_rows(
-      this.entries.slice(0, limit),
+      this.entries.slice(0, this.max_entries),
       this.style,
-      layout.links,
     );
-    const value = fit_rows(rows, this.entries.length, budget);
+    const value = fit_rows(rows, this.entries.length);
 
     if (value === null) {
       return null;
@@ -186,33 +120,26 @@ export class Scoreboard {
     };
   }
 
-  /**
-   * Discord user IDs of everyone with an entry on this scoreboard.
-   */
+  /** Discord user IDs of everyone with an entry on this scoreboard. */
   public get players(): Snowflake[] {
     return [...new Set(this.entries.map((entry) => entry.user.id))];
   }
 }
 
 /**
- * Joins as many rows as fit in `budget`, summarizing everything left over as `+ N more`.
+ * Joins as many rows as fit in one field, summarizing the rest as `+ N more`. Rows carry a link per
+ * player, so ten can run past the field limit on their own.
  *
- * Rows carry a link per player, so a busy day can run a scoreboard past what Discord accepts in a
- * field - and an embed Discord rejects means no summary at all. Trimming to fit keeps the top of
- * the scoreboard, which is the part worth reading.
- *
- * @returns {string | null} The field value, or `null` if there was not even room for one row.
+ * @returns {string | null} The field value, or `null` if there was not room for even one row.
  */
-function fit_rows(
-  rows: string[],
-  total_entries: number,
-  budget: number,
-): string | null {
-  const limit = Math.min(budget, MAX_FIELD_VALUE_LENGTH);
+function fit_rows(rows: string[], total_entries: number): string | null {
   const shown: string[] = [];
 
   for (const row of rows) {
-    if (render_value([...shown, row], total_entries).length > limit) {
+    if (
+      render_value([...shown, row], total_entries).length >
+      MAX_FIELD_VALUE_LENGTH
+    ) {
       break;
     }
     shown.push(row);
@@ -221,20 +148,14 @@ function fit_rows(
   return shown.length === 0 ? null : render_value(shown, total_entries);
 }
 
-/**
- * Joins rows into a field value, ending on a `+ N more` line if any entries are left out.
- */
+/** Ends on a `+ N more` line if any entries are left out. */
 function render_value(rows: string[], total_entries: number): string {
   const remainder = total_entries - rows.length;
 
   return (remainder > 0 ? [...rows, more_row(remainder)] : rows).join('\n');
 }
 
-/**
- * Renders the line standing in for entries the scoreboard had no room for.
- *
- * `-#` is Discord's subtext markup, which renders this smaller and greyer than a real row.
- */
+/** `-#` is Discord's subtext markup, rendering this smaller and greyer than a real row. */
 function more_row(remainder: number): string {
   return `-# + ${remainder} more`;
 }

--- a/src/core/embeds/embed_structure.ts
+++ b/src/core/embeds/embed_structure.ts
@@ -66,22 +66,26 @@ export class GameSummaryMessage {
       embeds: messages[0] ?? [],
     });
 
+    // Whatever happens below, every message that made it out must be tracked - an untracked
+    // message is invisible to cleanup and sits in the channel forever.
     const posted: Snowflake[] = [first.id];
-    for (const embeds of messages.slice(1)) {
-      const continuation = await interaction.followUp({ embeds: embeds });
-      posted.push(continuation.id);
+    try {
+      for (const embeds of messages.slice(1)) {
+        const continuation = await interaction.followUp({ embeds: embeds });
+        posted.push(continuation.id);
+      }
+
+      console.log(
+        `Sent summary in ${posted.length} message(s) to ${interaction.member?.user.username ?? interaction.user.username}.`,
+      );
+    } finally {
+      // Only once the new summary is up do we clear away the one it replaces.
+      const replaced = await GameSummaryMessage.track_summary(
+        interaction.channelId,
+        posted,
+      );
+      await GameSummaryMessage.delete_replaced_summary(interaction, replaced);
     }
-
-    console.log(
-      `Sent summary in ${posted.length} message(s) to ${interaction.member?.user.username ?? interaction.user.username}.`,
-    );
-
-    // Only once the new summary is up do we clear away the one it replaces.
-    const replaced = await GameSummaryMessage.track_summary(
-      interaction.channelId,
-      posted,
-    );
-    await GameSummaryMessage.delete_replaced_summary(interaction, replaced);
   }
 
   /**

--- a/src/core/embeds/embed_structure.ts
+++ b/src/core/embeds/embed_structure.ts
@@ -8,8 +8,30 @@ import {
 import Game from '../game.js';
 import { SummaryMessage, SummaryMessageModel } from '../database/schema.js';
 import { get_today } from '../../util.js';
-import { EmbedMessage } from './embed_types.js';
+import { EmbedMessage, ScoreCollection } from './embed_types.js';
+import {
+  LAYOUT_PREFERENCES,
+  Scoreboard,
+  ScoreboardLayout,
+} from './embed_formatter.js';
 
+/**
+ * Discord's limit on the combined character count of every embed in one message.
+ *
+ * The summary is sized to fit this rather than built blindly, because a message over the limit is
+ * rejected outright - which on the busiest day of the year would mean no summary at all.
+ */
+const MAX_MESSAGE_EMBED_LENGTH = 6000;
+
+/**
+ * Discord's limit on how many embeds one message may carry.
+ */
+const MAX_MESSAGE_EMBEDS = 10;
+
+/**
+ * Characters held back from the budget for each embed's footer.
+ */
+const FOOTER_ALLOWANCE = 48;
 
 /**
  * Represents a Discord message containing a summary of all game entries today.
@@ -38,12 +60,19 @@ export class GameSummaryMessage {
   async send(interaction: ButtonInteraction) {
     await interaction.deferReply();
 
+    const embeds = await this.get_embeds();
+    const content =
+      typeof this.message.content === 'string'
+        ? this.message.content
+        : this.message.content();
+
     const payload = {
+      // With no scoreboards to show there is nothing to explain the empty message, so say it.
       content:
-        typeof this.message.content === 'string'
-          ? this.message.content
-          : this.message.content(),
-      embeds: await this.get_embeds(),
+        embeds.length === 0 && this.message.empty
+          ? `${content}\n\n${this.message.empty}`
+          : content,
+      embeds: embeds,
     };
     const summary = await interaction.editReply(payload);
     console.log(
@@ -114,37 +143,159 @@ export class GameSummaryMessage {
   }
 
   private async get_embeds(): Promise<APIEmbed[]> {
+    const played = await this.load_played_collections();
+    if (played.length === 0) {
+      return [];
+    }
+
+    const layout = fit_layout(played);
     const embeds: APIEmbed[] = [];
+    let budget = MAX_MESSAGE_EMBED_LENGTH;
 
-    for (const embed_structure of this.message.embeds) {
+    for (const { collection, scoreboards } of played) {
       const fields: APIEmbedField[] = [];
+      const players = new Set<Snowflake>();
+      let entries = 0;
 
-      for (const field_structure of embed_structure.fields) {
-        const field = await field_structure.game.get_embed_field();
-        if (field !== null) {
-          fields.push(field);
+      budget -= collection.title.length + collection.description.length;
+
+      for (const { scoreboard, inline } of scoreboards) {
+        const rendered = scoreboard.render(
+          inline,
+          layout,
+          budget - FOOTER_ALLOWANCE,
+        );
+
+        if (rendered === null) {
+          continue;
         }
+
+        fields.push(rendered.field);
+        rendered.players.forEach((player) => players.add(player));
+        entries += rendered.entries;
+        budget -= rendered.field.name.length + rendered.field.value.length;
       }
 
-      // Only include collections someone has played today. Games with no entries produce no
-      // field, so an empty field list means nobody played anything in this collection.
+      // A collection whose scoreboards all got squeezed out contributes nothing but a title.
       if (fields.length === 0) {
         continue;
       }
 
-      const footer_options = embed_structure.footer
-        ? { text: embed_structure.footer }
-        : null;
+      const footer =
+        collection.footer ?? render_participation(players.size, entries);
+      budget -= footer.length;
 
       const embed = new EmbedBuilder()
-        .setTitle(embed_structure.title)
-        .setDescription(embed_structure.description)
+        .setTitle(collection.title)
+        .setDescription(collection.description)
         .addFields(fields)
-        .setFooter(footer_options).data;
+        .setFooter({ text: footer });
 
-      embeds.push(embed);
+      if (collection.color !== undefined) {
+        embed.setColor(collection.color);
+      }
+
+      embeds.push(embed.data);
     }
 
     return embeds;
   }
+
+  /**
+   * Loads every scoreboard with entries today, dropping the collections nobody played.
+   *
+   * Each game is one database query, and they are independent, so they go out together rather than
+   * one after another - the button this runs behind is waiting on all of them.
+   */
+  private async load_played_collections(): Promise<PlayedCollection[]> {
+    const collections = await Promise.all(
+      this.message.embeds.map(async (collection) => ({
+        collection: collection,
+        scoreboards: (
+          await Promise.all(
+            collection.fields.map(async (field) => {
+              const scoreboard = await field.game.load_scoreboard();
+
+              return scoreboard === null
+                ? null
+                : { scoreboard: scoreboard, inline: field.inline };
+            }),
+          )
+        ).filter((board): board is PlayedScoreboard => board !== null),
+      })),
+    );
+
+    // Only collections someone played today, and only as many embeds as Discord will carry in one
+    // message - anything past that is dropped before it can eat into the character budget.
+    return collections
+      .filter((collection) => collection.scoreboards.length > 0)
+      .slice(0, MAX_MESSAGE_EMBEDS);
+  }
+}
+
+/**
+ * A score collection with at least one game played today.
+ */
+interface PlayedCollection {
+  collection: ScoreCollection;
+  scoreboards: PlayedScoreboard[];
+}
+
+interface PlayedScoreboard {
+  scoreboard: Scoreboard;
+  inline: boolean;
+}
+
+/**
+ * Picks the best layout from `LAYOUT_PREFERENCES` that fits inside Discord's embed budget.
+ *
+ * Every scoreboard is laid out the same way, which is what keeps a busy day fair: spending the
+ * budget on whichever collections happen to come first would show the New York Times in full and
+ * drop 4x3 entirely. Cutting all of them back instead leaves every game someone played on the
+ * summary.
+ *
+ * @returns {ScoreboardLayout} The layout to render in, falling back to the smallest one, in which
+ * case rendering trims from the end as a last resort.
+ */
+function fit_layout(played: PlayedCollection[]): ScoreboardLayout {
+  const fits = LAYOUT_PREFERENCES.find(
+    (layout) => measure(played, layout) <= MAX_MESSAGE_EMBED_LENGTH,
+  );
+
+  return fits ?? LAYOUT_PREFERENCES[LAYOUT_PREFERENCES.length - 1];
+}
+
+/**
+ * Counts the characters the summary would take up in the given layout.
+ */
+function measure(played: PlayedCollection[], layout: ScoreboardLayout): number {
+  return played.reduce(
+    (total, { collection, scoreboards }) =>
+      total +
+      collection.title.length +
+      collection.description.length +
+      FOOTER_ALLOWANCE +
+      scoreboards.reduce((sum, { scoreboard, inline }) => {
+        const rendered = scoreboard.render(inline, layout);
+        return (
+          sum +
+          (rendered
+            ? rendered.field.name.length + rendered.field.value.length
+            : 0)
+        );
+      }, 0),
+    0,
+  );
+}
+
+/**
+ * Renders a collection's footer, e.g. `3 players · 7 entries`.
+ *
+ * Says how much of the collection was actually played, which the scoreboards themselves cannot -
+ * a scoreboard only shows the games someone got round to.
+ */
+function render_participation(players: number, entries: number): string {
+  return `${players} ${players === 1 ? 'player' : 'players'} · ${entries} ${
+    entries === 1 ? 'entry' : 'entries'
+  }`;
 }

--- a/src/core/embeds/embed_structure.ts
+++ b/src/core/embeds/embed_structure.ts
@@ -9,33 +9,19 @@ import Game from '../game.js';
 import { SummaryMessage, SummaryMessageModel } from '../database/schema.js';
 import { get_today } from '../../util.js';
 import { EmbedMessage, ScoreCollection } from './embed_types.js';
-import {
-  LAYOUT_PREFERENCES,
-  Scoreboard,
-  ScoreboardLayout,
-} from './embed_formatter.js';
+import { Scoreboard } from './embed_formatter.js';
 
 /**
- * Discord's limit on the combined character count of every embed in one message.
+ * Discord's character limit, both on a single embed and on every embed in one message combined.
  *
- * A message over the limit is rejected outright, so a summary too big for one message is split
- * across several rather than cut down to fit.
+ * A message over the limit is rejected outright, so a summary too big for one is split across as
+ * many as it takes rather than cut down to fit. Collections are packed whole, so the only thing
+ * splitting cannot rescue is a single embed over the limit - see the warning in `pack_messages`.
  */
-const MAX_MESSAGE_EMBED_LENGTH = 6000;
+const MAX_EMBED_LENGTH = 6000;
 
-/**
- * Discord's limit on how many embeds one message may carry.
- */
+/** Discord's limit on how many embeds one message may carry. */
 const MAX_MESSAGE_EMBEDS = 10;
-
-/**
- * Messages one summary may span before it starts leaving things out instead.
- *
- * Splitting is better than dropping content, but a summary that goes on for screens is its own kind
- * of unreadable - so past this many messages the layout gives something up instead, see
- * `LAYOUT_PREFERENCES`.
- */
-const MAX_SUMMARY_MESSAGES = 3;
 
 /**
  * Represents a Discord message containing a summary of all game entries today.
@@ -44,8 +30,6 @@ export class GameSummaryMessage {
   private message: EmbedMessage;
 
   /**
-   * Initializes a game summary message with the given message.
-   *
    * @param {EmbedMessage} message The message.
    */
   constructor(message: EmbedMessage) {
@@ -165,45 +149,20 @@ export class GameSummaryMessage {
   }
 
   /**
-   * Builds the summary as a list of messages, each a list of embeds that fits what Discord accepts
-   * in one message.
-   *
-   * Every collection is rendered whole and then packed into messages, so nothing is trimmed just to
-   * make a message boundary work out. Only if the summary would still span more than
-   * `MAX_SUMMARY_MESSAGES` does the layout start giving something up.
+   * Builds the summary as a list of messages, each a list of embeds. Collections are rendered whole
+   * and packed into as many messages as it takes, so nothing is trimmed to fit a boundary.
    *
    * @returns {Promise<APIEmbed[][]>} One list of embeds per message, or empty if nobody played.
    */
   private async build_messages(): Promise<APIEmbed[][]> {
     const played = await this.load_played_collections();
-    if (played.length === 0) {
-      return [];
-    }
 
-    for (const layout of LAYOUT_PREFERENCES) {
-      const messages = pack_messages(render_collections(played, layout));
-
-      if (messages.length <= MAX_SUMMARY_MESSAGES) {
-        return messages;
-      }
-    }
-
-    // Nothing fit, which takes more collections than this bot has games. Show what will fit in the
-    // smallest layout and let the rest go.
-    const smallest = LAYOUT_PREFERENCES[LAYOUT_PREFERENCES.length - 1];
-    const messages = pack_messages(render_collections(played, smallest));
-    console.warn(
-      `Summary did not fit in ${MAX_SUMMARY_MESSAGES} messages; dropping ${messages.length - MAX_SUMMARY_MESSAGES} message(s) worth of collections.`,
-    );
-
-    return messages.slice(0, MAX_SUMMARY_MESSAGES);
+    return played.length === 0 ? [] : pack_messages(render_collections(played));
   }
 
   /**
-   * Loads every scoreboard with entries today, dropping the collections nobody played.
-   *
-   * Each game is one database query, and they are independent, so they go out together rather than
-   * one after another - the button this runs behind is waiting on all of them.
+   * Loads every scoreboard with entries today, dropping the collections nobody played. One query per
+   * game, issued together rather than in sequence - the button press is waiting on all of them.
    */
   private async load_played_collections(): Promise<PlayedCollection[]> {
     const collections = await Promise.all(
@@ -229,13 +188,8 @@ export class GameSummaryMessage {
   }
 }
 
-/**
- * Renders one embed per played collection, at the given layout.
- */
-function render_collections(
-  played: PlayedCollection[],
-  layout: ScoreboardLayout,
-): APIEmbed[] {
+/** Renders one embed per played collection. */
+function render_collections(played: PlayedCollection[]): APIEmbed[] {
   const embeds: APIEmbed[] = [];
 
   for (const { collection, scoreboards } of played) {
@@ -244,7 +198,7 @@ function render_collections(
     let entries = 0;
 
     for (const { scoreboard, inline } of scoreboards) {
-      const rendered = scoreboard.render(inline, layout);
+      const rendered = scoreboard.render(inline);
 
       if (rendered === null) {
         continue;
@@ -278,9 +232,8 @@ function render_collections(
 }
 
 /**
- * Packs embeds into messages, filling each one up to Discord's limits before starting the next.
- *
- * Collections are kept whole: an embed goes entirely into one message or entirely into the next.
+ * Fills each message up to Discord's limits before starting the next, keeping collections whole - an
+ * embed goes entirely into one message or entirely into the next.
  */
 function pack_messages(embeds: APIEmbed[]): APIEmbed[][] {
   const messages: APIEmbed[][] = [];
@@ -289,9 +242,16 @@ function pack_messages(embeds: APIEmbed[]): APIEmbed[][] {
 
   for (const embed of embeds) {
     const embed_size = embed_length(embed);
+
+    if (embed_size > MAX_EMBED_LENGTH) {
+      console.warn(
+        `Embed '${embed.title}' is ${embed_size} characters, over Discord's ${MAX_EMBED_LENGTH} limit for one embed. Splitting cannot help - the collection has too many games for one embed.`,
+      );
+    }
+
     const full =
       current.length >= MAX_MESSAGE_EMBEDS ||
-      length + embed_size > MAX_MESSAGE_EMBED_LENGTH;
+      length + embed_size > MAX_EMBED_LENGTH;
 
     if (full && current.length > 0) {
       messages.push(current);
@@ -310,9 +270,7 @@ function pack_messages(embeds: APIEmbed[]): APIEmbed[][] {
   return messages;
 }
 
-/**
- * Counts the characters Discord counts against an embed.
- */
+/** Counts the characters Discord counts against an embed. */
 function embed_length(embed: APIEmbed): number {
   return (
     (embed.title?.length ?? 0) +
@@ -325,10 +283,7 @@ function embed_length(embed: APIEmbed): number {
   );
 }
 
-/**
- * Every message a tracked summary was made up of, including rows written before summaries could
- * span more than one message.
- */
+/** Also reads rows written before summaries could span more than one message. */
 function replaced_message_ids(replaced: SummaryMessage): Snowflake[] {
   if (replaced.message_ids?.length) {
     return replaced.message_ids;
@@ -350,12 +305,7 @@ interface PlayedScoreboard {
   inline: boolean;
 }
 
-/**
- * Renders a collection's footer, e.g. `3 players · 7 entries`.
- *
- * Says how much of the collection was actually played, which the scoreboards themselves cannot -
- * a scoreboard only shows the games someone got round to.
- */
+/** Renders a collection's footer, e.g. `3 players · 7 entries`. */
 function render_participation(players: number, entries: number): string {
   return `${players} ${players === 1 ? 'player' : 'players'} · ${entries} ${
     entries === 1 ? 'entry' : 'entries'

--- a/src/core/embeds/embed_structure.ts
+++ b/src/core/embeds/embed_structure.ts
@@ -18,8 +18,8 @@ import {
 /**
  * Discord's limit on the combined character count of every embed in one message.
  *
- * The summary is sized to fit this rather than built blindly, because a message over the limit is
- * rejected outright - which on the busiest day of the year would mean no summary at all.
+ * A message over the limit is rejected outright, so a summary too big for one message is split
+ * across several rather than cut down to fit.
  */
 const MAX_MESSAGE_EMBED_LENGTH = 6000;
 
@@ -29,9 +29,13 @@ const MAX_MESSAGE_EMBED_LENGTH = 6000;
 const MAX_MESSAGE_EMBEDS = 10;
 
 /**
- * Characters held back from the budget for each embed's footer.
+ * Messages one summary may span before it starts leaving things out instead.
+ *
+ * Splitting is better than dropping content, but a summary that goes on for screens is its own kind
+ * of unreadable - so past this many messages the layout gives something up instead, see
+ * `LAYOUT_PREFERENCES`.
  */
-const FOOTER_ALLOWANCE = 48;
+const MAX_SUMMARY_MESSAGES = 3;
 
 /**
  * Represents a Discord message containing a summary of all game entries today.
@@ -49,8 +53,11 @@ export class GameSummaryMessage {
   }
 
   /**
-   * Sends the game summary message as a reply to the given button interaction, then deletes the
-   * summary message it replaces - see `delete_replaced_summary`.
+   * Sends the game summary as a reply to the given button interaction, then deletes the summary it
+   * replaces - see `delete_replaced_summary`.
+   *
+   * A summary too big for one message continues into follow-up messages. The first goes out as the
+   * reply to the button so the press is answered, and the rest follow it in order.
    *
    * The interaction is deferred before anything else, because building the summary hits the
    * database and Discord discards interactions that are not acknowledged within three seconds.
@@ -60,35 +67,41 @@ export class GameSummaryMessage {
   async send(interaction: ButtonInteraction) {
     await interaction.deferReply();
 
-    const embeds = await this.get_embeds();
+    const messages = await this.build_messages();
     const content =
       typeof this.message.content === 'string'
         ? this.message.content
         : this.message.content();
 
-    const payload = {
+    const first = await interaction.editReply({
       // With no scoreboards to show there is nothing to explain the empty message, so say it.
       content:
-        embeds.length === 0 && this.message.empty
+        messages.length === 0 && this.message.empty
           ? `${content}\n\n${this.message.empty}`
           : content,
-      embeds: embeds,
-    };
-    const summary = await interaction.editReply(payload);
+      embeds: messages[0] ?? [],
+    });
+
+    const posted: Snowflake[] = [first.id];
+    for (const embeds of messages.slice(1)) {
+      const continuation = await interaction.followUp({ embeds: embeds });
+      posted.push(continuation.id);
+    }
+
     console.log(
-      `Sent summary message to ${interaction.member?.user.username ?? interaction.user.username}.`,
+      `Sent summary in ${posted.length} message(s) to ${interaction.member?.user.username ?? interaction.user.username}.`,
     );
 
     // Only once the new summary is up do we clear away the one it replaces.
     const replaced = await GameSummaryMessage.track_summary(
       interaction.channelId,
-      summary.id,
+      posted,
     );
     await GameSummaryMessage.delete_replaced_summary(interaction, replaced);
   }
 
   /**
-   * Records `message_id` as the current summary message for `channel_id`, and returns the entry it
+   * Records `message_ids` as the current summary for `channel_id`, and returns the entry it
    * replaced - if any.
    *
    * The swap is a single atomic update so that two people clicking the summary button at the same
@@ -96,18 +109,23 @@ export class GameSummaryMessage {
    */
   private static async track_summary(
     channel_id: Snowflake,
-    message_id: Snowflake,
+    message_ids: Snowflake[],
   ): Promise<SummaryMessage | null> {
     return await SummaryMessageModel.findOneAndUpdate(
       { channel_id: channel_id },
-      { channel_id: channel_id, message_id: message_id },
+      {
+        $set: { channel_id: channel_id, message_ids: message_ids },
+        // Clear the single-message field, so a row written by an older version is not left behind
+        // pointing at a message this one has already accounted for.
+        $unset: { message_id: '' },
+      },
       { upsert: true },
     ).exec();
   }
 
   /**
-   * Deletes a summary message that has been replaced by a newer one, keeping a single summary per
-   * channel per day.
+   * Deletes a summary that has been replaced by a newer one, keeping a single summary per channel
+   * per day. All of the replaced summary's messages go, not just the first.
    *
    * Summaries from previous days are left alone - those are a record of that day. Failing to
    * delete is not treated as an error: the message may well be gone already.
@@ -121,14 +139,18 @@ export class GameSummaryMessage {
       return;
     }
 
-    await interaction.channel?.messages
-      .fetch(replaced.message_id)
-      .then((message) => message.delete())
-      .catch((err) =>
-        console.info(
-          `Could not delete replaced summary message ${replaced.message_id}: ${err}`,
-        ),
-      );
+    await Promise.all(
+      replaced_message_ids(replaced).map((message_id) =>
+        interaction.channel?.messages
+          .fetch(message_id)
+          .then((message) => message.delete())
+          .catch((err) =>
+            console.info(
+              `Could not delete replaced summary message ${message_id}: ${err}`,
+            ),
+          ),
+      ),
+    );
   }
 
   /**
@@ -142,63 +164,39 @@ export class GameSummaryMessage {
     );
   }
 
-  private async get_embeds(): Promise<APIEmbed[]> {
+  /**
+   * Builds the summary as a list of messages, each a list of embeds that fits what Discord accepts
+   * in one message.
+   *
+   * Every collection is rendered whole and then packed into messages, so nothing is trimmed just to
+   * make a message boundary work out. Only if the summary would still span more than
+   * `MAX_SUMMARY_MESSAGES` does the layout start giving something up.
+   *
+   * @returns {Promise<APIEmbed[][]>} One list of embeds per message, or empty if nobody played.
+   */
+  private async build_messages(): Promise<APIEmbed[][]> {
     const played = await this.load_played_collections();
     if (played.length === 0) {
       return [];
     }
 
-    const layout = fit_layout(played);
-    const embeds: APIEmbed[] = [];
-    let budget = MAX_MESSAGE_EMBED_LENGTH;
+    for (const layout of LAYOUT_PREFERENCES) {
+      const messages = pack_messages(render_collections(played, layout));
 
-    for (const { collection, scoreboards } of played) {
-      const fields: APIEmbedField[] = [];
-      const players = new Set<Snowflake>();
-      let entries = 0;
-
-      budget -= collection.title.length + collection.description.length;
-
-      for (const { scoreboard, inline } of scoreboards) {
-        const rendered = scoreboard.render(
-          inline,
-          layout,
-          budget - FOOTER_ALLOWANCE,
-        );
-
-        if (rendered === null) {
-          continue;
-        }
-
-        fields.push(rendered.field);
-        rendered.players.forEach((player) => players.add(player));
-        entries += rendered.entries;
-        budget -= rendered.field.name.length + rendered.field.value.length;
+      if (messages.length <= MAX_SUMMARY_MESSAGES) {
+        return messages;
       }
-
-      // A collection whose scoreboards all got squeezed out contributes nothing but a title.
-      if (fields.length === 0) {
-        continue;
-      }
-
-      const footer =
-        collection.footer ?? render_participation(players.size, entries);
-      budget -= footer.length;
-
-      const embed = new EmbedBuilder()
-        .setTitle(collection.title)
-        .setDescription(collection.description)
-        .addFields(fields)
-        .setFooter({ text: footer });
-
-      if (collection.color !== undefined) {
-        embed.setColor(collection.color);
-      }
-
-      embeds.push(embed.data);
     }
 
-    return embeds;
+    // Nothing fit, which takes more collections than this bot has games. Show what will fit in the
+    // smallest layout and let the rest go.
+    const smallest = LAYOUT_PREFERENCES[LAYOUT_PREFERENCES.length - 1];
+    const messages = pack_messages(render_collections(played, smallest));
+    console.warn(
+      `Summary did not fit in ${MAX_SUMMARY_MESSAGES} messages; dropping ${messages.length - MAX_SUMMARY_MESSAGES} message(s) worth of collections.`,
+    );
+
+    return messages.slice(0, MAX_SUMMARY_MESSAGES);
   }
 
   /**
@@ -225,12 +223,118 @@ export class GameSummaryMessage {
       })),
     );
 
-    // Only collections someone played today, and only as many embeds as Discord will carry in one
-    // message - anything past that is dropped before it can eat into the character budget.
-    return collections
-      .filter((collection) => collection.scoreboards.length > 0)
-      .slice(0, MAX_MESSAGE_EMBEDS);
+    return collections.filter(
+      (collection) => collection.scoreboards.length > 0,
+    );
   }
+}
+
+/**
+ * Renders one embed per played collection, at the given layout.
+ */
+function render_collections(
+  played: PlayedCollection[],
+  layout: ScoreboardLayout,
+): APIEmbed[] {
+  const embeds: APIEmbed[] = [];
+
+  for (const { collection, scoreboards } of played) {
+    const fields: APIEmbedField[] = [];
+    const players = new Set<Snowflake>();
+    let entries = 0;
+
+    for (const { scoreboard, inline } of scoreboards) {
+      const rendered = scoreboard.render(inline, layout);
+
+      if (rendered === null) {
+        continue;
+      }
+
+      fields.push(rendered.field);
+      rendered.players.forEach((player) => players.add(player));
+      entries += rendered.entries;
+    }
+
+    if (fields.length === 0) {
+      continue;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle(collection.title)
+      .setDescription(collection.description)
+      .addFields(fields)
+      .setFooter({
+        text: collection.footer ?? render_participation(players.size, entries),
+      });
+
+    if (collection.color !== undefined) {
+      embed.setColor(collection.color);
+    }
+
+    embeds.push(embed.data);
+  }
+
+  return embeds;
+}
+
+/**
+ * Packs embeds into messages, filling each one up to Discord's limits before starting the next.
+ *
+ * Collections are kept whole: an embed goes entirely into one message or entirely into the next.
+ */
+function pack_messages(embeds: APIEmbed[]): APIEmbed[][] {
+  const messages: APIEmbed[][] = [];
+  let current: APIEmbed[] = [];
+  let length = 0;
+
+  for (const embed of embeds) {
+    const embed_size = embed_length(embed);
+    const full =
+      current.length >= MAX_MESSAGE_EMBEDS ||
+      length + embed_size > MAX_MESSAGE_EMBED_LENGTH;
+
+    if (full && current.length > 0) {
+      messages.push(current);
+      current = [];
+      length = 0;
+    }
+
+    current.push(embed);
+    length += embed_size;
+  }
+
+  if (current.length > 0) {
+    messages.push(current);
+  }
+
+  return messages;
+}
+
+/**
+ * Counts the characters Discord counts against an embed.
+ */
+function embed_length(embed: APIEmbed): number {
+  return (
+    (embed.title?.length ?? 0) +
+    (embed.description?.length ?? 0) +
+    (embed.footer?.text.length ?? 0) +
+    (embed.fields ?? []).reduce(
+      (total, field) => total + field.name.length + field.value.length,
+      0,
+    )
+  );
+}
+
+/**
+ * Every message a tracked summary was made up of, including rows written before summaries could
+ * span more than one message.
+ */
+function replaced_message_ids(replaced: SummaryMessage): Snowflake[] {
+  if (replaced.message_ids?.length) {
+    return replaced.message_ids;
+  }
+
+  return replaced.message_id ? [replaced.message_id] : [];
 }
 
 /**
@@ -244,48 +348,6 @@ interface PlayedCollection {
 interface PlayedScoreboard {
   scoreboard: Scoreboard;
   inline: boolean;
-}
-
-/**
- * Picks the best layout from `LAYOUT_PREFERENCES` that fits inside Discord's embed budget.
- *
- * Every scoreboard is laid out the same way, which is what keeps a busy day fair: spending the
- * budget on whichever collections happen to come first would show the New York Times in full and
- * drop 4x3 entirely. Cutting all of them back instead leaves every game someone played on the
- * summary.
- *
- * @returns {ScoreboardLayout} The layout to render in, falling back to the smallest one, in which
- * case rendering trims from the end as a last resort.
- */
-function fit_layout(played: PlayedCollection[]): ScoreboardLayout {
-  const fits = LAYOUT_PREFERENCES.find(
-    (layout) => measure(played, layout) <= MAX_MESSAGE_EMBED_LENGTH,
-  );
-
-  return fits ?? LAYOUT_PREFERENCES[LAYOUT_PREFERENCES.length - 1];
-}
-
-/**
- * Counts the characters the summary would take up in the given layout.
- */
-function measure(played: PlayedCollection[], layout: ScoreboardLayout): number {
-  return played.reduce(
-    (total, { collection, scoreboards }) =>
-      total +
-      collection.title.length +
-      collection.description.length +
-      FOOTER_ALLOWANCE +
-      scoreboards.reduce((sum, { scoreboard, inline }) => {
-        const rendered = scoreboard.render(inline, layout);
-        return (
-          sum +
-          (rendered
-            ? rendered.field.name.length + rendered.field.value.length
-            : 0)
-        );
-      }, 0),
-    0,
-  );
 }
 
 /**

--- a/src/core/embeds/embed_types.ts
+++ b/src/core/embeds/embed_types.ts
@@ -1,8 +1,7 @@
 import Game from '../game.js';
 
 /**
- * An a single field entry in a score collection.
- * Example: 
+ * One scoreboard in a score collection.
  */
 export interface ScoreField {
   game: Game;
@@ -10,12 +9,22 @@ export interface ScoreField {
 }
 
 /**
- * A collection of field entries, with related title and description data.
+ * A collection of scoreboards for related games, e.g. everything from the New York Times.
  */
 export interface ScoreCollection {
   title: string;
   description: string;
   fields: ScoreField[];
+
+  /**
+   * Colour of the embed's left edge, as `0xRRGGBB`. Giving each collection its own colour is what
+   * makes a wall of summary embeds skimmable.
+   */
+  color?: number;
+
+  /**
+   * Footer text. Defaults to a count of who played, see `render_participation`.
+   */
   footer?: string;
 }
 
@@ -25,4 +34,10 @@ export interface ScoreCollection {
 export interface EmbedMessage {
   content: string | (() => string);
   embeds: ScoreCollection[];
+
+  /**
+   * Appended to `content` on a day nobody has registered a score yet, when there are no scoreboards
+   * to show at all.
+   */
+  empty?: string;
 }

--- a/src/core/embeds/embed_types.ts
+++ b/src/core/embeds/embed_types.ts
@@ -1,8 +1,6 @@
 import Game from '../game.js';
 
-/**
- * One scoreboard in a score collection.
- */
+/** One scoreboard in a score collection. */
 export interface ScoreField {
   game: Game;
   inline: boolean;
@@ -16,15 +14,10 @@ export interface ScoreCollection {
   description: string;
   fields: ScoreField[];
 
-  /**
-   * Colour of the embed's left edge, as `0xRRGGBB`. Giving each collection its own colour is what
-   * makes a wall of summary embeds skimmable.
-   */
+  /** Colour of the embed's left edge, as `0xRRGGBB`. */
   color?: number;
 
-  /**
-   * Footer text. Defaults to a count of who played, see `render_participation`.
-   */
+  /** Defaults to a count of who played, see `render_participation`. */
   footer?: string;
 }
 
@@ -35,9 +28,6 @@ export interface EmbedMessage {
   content: string | (() => string);
   embeds: ScoreCollection[];
 
-  /**
-   * Appended to `content` on a day nobody has registered a score yet, when there are no scoreboards
-   * to show at all.
-   */
+  /** Appended to `content` on a day with no scoreboards to show at all. */
   empty?: string;
 }

--- a/src/core/embeds/scoreboard.ts
+++ b/src/core/embeds/scoreboard.ts
@@ -1,95 +1,54 @@
 import { GameEntry } from '../database/schema.js';
 
-/**
- * Awarded to the first three ranks of a scoreboard.
- */
 const MEDALS = ['🥇', '🥈', '🥉'];
 
-/**
- * Appended to a flawless result.
- */
 const PERFECT = '✨';
 
-/**
- * Appended to a result that never solved the puzzle.
- */
 const FAILED = '💀';
 
-/**
- * Renders a stored score as it should read in a scoreboard's score column.
- *
- * Scores are stored as whatever was easiest to parse out of a shared result - seconds for timed
- * games, `hints,words,total` for Strands - so this is where a game turns storage into something
- * worth looking at.
- */
+/** Renders a stored score as it should read in the score column. */
 export interface ScoreDisplay {
   (score: string): string;
 }
 
-/**
- * Reads a stored score as a number so it can be ranked. `NaN` ranks last, whichever direction the
- * scoreboard sorts in, which is how unsolved puzzles end up at the bottom.
- */
+/** Reads a stored score as a number for ranking. `NaN` always ranks last. */
 export interface ScoreValue {
   (score: string): number;
 }
 
-/**
- * Answers a yes/no question about a stored score, e.g. whether it solved the puzzle.
- */
 export interface ScorePredicate {
   (score: string): boolean;
 }
 
-/**
- * A function that sorts game entries, best result first.
- */
+/** Sorts game entries, best result first. */
 export interface ScoreSorter {
   (a: GameEntry, b: GameEntry): number;
 }
 
 /**
- * How a game's results are presented on the summary scoreboard.
- *
- * Everything is optional: a game that scores plainly - one number, lower is better, no way to lose
- * - needs none of it.
+ * How a game's results are presented on the summary scoreboard. All optional - a game scored on one
+ * number, lower being better, with no way to lose, needs none of it.
  */
 export interface ScoreboardStyle {
-  /**
-   * Heading of the scoreboard. Defaults to the name the game's entries are stored under, which is
-   * not always presentable - `GlobleCapitals`, `🌱 Bullpen`.
-   */
+  /** Defaults to the name entries are stored under, which is not always presentable. */
   title?: string;
 
-  /**
-   * What the score measures, e.g. `guesses`, shown after the title. Without it a bare number on a
-   * scoreboard is a guess at whether more or less of it is better.
-   */
+  /** What the score measures, e.g. `guesses`, shown after the title. */
   unit?: string;
 
-  /**
-   * Renders the score column. Defaults to the score exactly as stored.
-   */
+  /** Defaults to the score exactly as stored. */
   display?: ScoreDisplay;
 
-  /**
-   * Whether a score is flawless, and so worth an ✨.
-   */
+  /** Marked with ✨. */
   is_perfect?: ScorePredicate;
 
-  /**
-   * Whether a score failed to solve the puzzle. Those get a 💀 and never take a medal, so that a
-   * day where everybody failed does not crown a winner.
-   */
+  /** Marked with 💀, and never given a medal. */
   is_failed?: ScorePredicate;
 }
 
 /**
- * Reads the leading number of a score.
- *
- * Handles the shapes games actually store: `3/6` is three, `X/6` is `NaN`, `0,8,8` is zero, and
- * thousands separators in a score like TimeGuessr's `44,123` are read as one number rather than
- * truncated at the comma.
+ * Reads the leading number of a score: `3/6` is three, `X/6` is `NaN`, `0,8,8` is zero, and
+ * TimeGuessr's `44,123` is read whole rather than truncated at the comma.
  */
 export const numeric: ScoreValue = (score) =>
   parseFloat(score.replace(/,(?=\d{3}(?:\D|$))/g, ''));
@@ -114,9 +73,7 @@ export const highest_first =
   (a, b) =>
     compare(value(a.score), value(b.score), -1);
 
-/**
- * Compares two score values in the given direction, ranking unreadable scores last either way.
- */
+/** Ranks unreadable scores last, whichever direction is sorted in. */
 function compare(x: number, y: number, direction: number): number {
   if (isNaN(x)) {
     return isNaN(y) ? 0 : 1;
@@ -124,12 +81,7 @@ function compare(x: number, y: number, direction: number): number {
   return isNaN(y) ? -1 : (x - y) * direction;
 }
 
-/**
- * Builds the heading of a scoreboard, e.g. `Wordle · guesses`.
- *
- * @param {ScoreboardStyle} style - The game's scoreboard style.
- * @param {string} fallback_title - Title to use when the style does not name one.
- */
+/** Builds the heading of a scoreboard, e.g. `Wordle · guesses`. */
 export function render_heading(
   style: ScoreboardStyle,
   fallback_title: string,
@@ -140,26 +92,16 @@ export function render_heading(
 }
 
 /**
- * Renders one scoreboard row per entry, e.g. ``🥇 `3/6` [Jørgen](…)``.
+ * Renders one scoreboard row per entry, e.g. ``🥇 `3/6` [Jørgen](…)``. `entries` must already be
+ * sorted best first, as rank comes from position in the list.
  *
- * `entries` must already be sorted best first - rank comes from position in the list, and entries
- * showing the same score share a rank.
- *
- * Scores are padded to a common width inside inline code so they line up as a column. Inline code
- * is the only monospace Discord offers that still renders a link next to it, and padding on the
- * front only keeps the padding from being stripped as code fence padding.
- *
- * @param {GameEntry[]} entries - Today's entries for one game, best first.
- * @param {ScoreboardStyle} style - How this game's scores are presented.
- * @param {boolean} [links=true] - Whether names link to the message the score was shared in. The
- * link is most of a row's length, so a summary too big for Discord gives these up - see
- * `LAYOUT_PREFERENCES`.
- * @returns {string[]} One rendered row per entry, in the same order.
+ * Scores are padded inside inline code to line up as a column - it is the only monospace Discord
+ * offers that still renders a link beside it, and padding only the front keeps Discord from
+ * stripping it.
  */
 export function render_rows(
   entries: GameEntry[],
   style: ScoreboardStyle,
-  links: boolean = true,
 ): string[] {
   if (entries.length === 0) {
     return [];
@@ -173,8 +115,7 @@ export function render_rows(
   let previous_score: string | undefined;
 
   return entries.map((entry, index) => {
-    // Position in the list is the rank, except for entries showing the same score as the one above
-    // them, which keep that entry's rank.
+    // Entries showing the same score share a rank.
     if (scores[index] !== previous_score) {
       rank = index + 1;
       previous_score = scores[index];
@@ -188,31 +129,23 @@ export function render_rows(
         : '';
 
     const score = `\`${scores[index].padStart(width)}\``;
-    const user = links ? render_user_link(entry) : render_user(entry);
 
-    return `${render_rank(rank, failed)} ${score} ${user}${marker}`;
+    return `${render_rank(rank, failed)} ${score} ${render_user_link(entry)}${marker}`;
   });
 }
 
-/**
- * Renders a rank as a medal, or as a plain number once the medals run out.
- */
+/** A medal, or a plain number once the medals run out. */
 function render_rank(rank: number, failed: boolean): string {
   return !failed && rank <= MEDALS.length ? MEDALS[rank - 1] : `\`${rank}.\``;
 }
 
-/**
- * Renders a player's name as a link to the message their score was shared in.
- */
+/** Links the player's name to the message they shared their score in. */
 function render_user_link(entry: GameEntry): string {
   const message_url = `https://discord.com/channels/${entry.server_id}/${entry.channel_id}/${entry.message_id}`;
 
   return `[${render_user(entry)}](${message_url})`;
 }
 
-/**
- * Renders a player's name.
- */
 function render_user(entry: GameEntry): string {
   return entry.user.server_name ?? entry.user.name;
 }

--- a/src/core/embeds/scoreboard.ts
+++ b/src/core/embeds/scoreboard.ts
@@ -1,0 +1,218 @@
+import { GameEntry } from '../database/schema.js';
+
+/**
+ * Awarded to the first three ranks of a scoreboard.
+ */
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+/**
+ * Appended to a flawless result.
+ */
+const PERFECT = '✨';
+
+/**
+ * Appended to a result that never solved the puzzle.
+ */
+const FAILED = '💀';
+
+/**
+ * Renders a stored score as it should read in a scoreboard's score column.
+ *
+ * Scores are stored as whatever was easiest to parse out of a shared result - seconds for timed
+ * games, `hints,words,total` for Strands - so this is where a game turns storage into something
+ * worth looking at.
+ */
+export interface ScoreDisplay {
+  (score: string): string;
+}
+
+/**
+ * Reads a stored score as a number so it can be ranked. `NaN` ranks last, whichever direction the
+ * scoreboard sorts in, which is how unsolved puzzles end up at the bottom.
+ */
+export interface ScoreValue {
+  (score: string): number;
+}
+
+/**
+ * Answers a yes/no question about a stored score, e.g. whether it solved the puzzle.
+ */
+export interface ScorePredicate {
+  (score: string): boolean;
+}
+
+/**
+ * A function that sorts game entries, best result first.
+ */
+export interface ScoreSorter {
+  (a: GameEntry, b: GameEntry): number;
+}
+
+/**
+ * How a game's results are presented on the summary scoreboard.
+ *
+ * Everything is optional: a game that scores plainly - one number, lower is better, no way to lose
+ * - needs none of it.
+ */
+export interface ScoreboardStyle {
+  /**
+   * Heading of the scoreboard. Defaults to the name the game's entries are stored under, which is
+   * not always presentable - `GlobleCapitals`, `🌱 Bullpen`.
+   */
+  title?: string;
+
+  /**
+   * What the score measures, e.g. `guesses`, shown after the title. Without it a bare number on a
+   * scoreboard is a guess at whether more or less of it is better.
+   */
+  unit?: string;
+
+  /**
+   * Renders the score column. Defaults to the score exactly as stored.
+   */
+  display?: ScoreDisplay;
+
+  /**
+   * Whether a score is flawless, and so worth an ✨.
+   */
+  is_perfect?: ScorePredicate;
+
+  /**
+   * Whether a score failed to solve the puzzle. Those get a 💀 and never take a medal, so that a
+   * day where everybody failed does not crown a winner.
+   */
+  is_failed?: ScorePredicate;
+}
+
+/**
+ * Reads the leading number of a score.
+ *
+ * Handles the shapes games actually store: `3/6` is three, `X/6` is `NaN`, `0,8,8` is zero, and
+ * thousands separators in a score like TimeGuessr's `44,123` are read as one number rather than
+ * truncated at the comma.
+ */
+export const numeric: ScoreValue = (score) =>
+  parseFloat(score.replace(/,(?=\d{3}(?:\D|$))/g, ''));
+
+/**
+ * Sorts entries by score, lowest first - guesses, mistakes, moves, solve times.
+ *
+ * @param {ScoreValue} [value=numeric] - Reads the number to sort on out of a stored score.
+ */
+export const lowest_first =
+  (value: ScoreValue = numeric): ScoreSorter =>
+  (a, b) =>
+    compare(value(a.score), value(b.score), 1);
+
+/**
+ * Sorts entries by score, highest first - points, correct answers.
+ *
+ * @param {ScoreValue} [value=numeric] - Reads the number to sort on out of a stored score.
+ */
+export const highest_first =
+  (value: ScoreValue = numeric): ScoreSorter =>
+  (a, b) =>
+    compare(value(a.score), value(b.score), -1);
+
+/**
+ * Compares two score values in the given direction, ranking unreadable scores last either way.
+ */
+function compare(x: number, y: number, direction: number): number {
+  if (isNaN(x)) {
+    return isNaN(y) ? 0 : 1;
+  }
+  return isNaN(y) ? -1 : (x - y) * direction;
+}
+
+/**
+ * Builds the heading of a scoreboard, e.g. `Wordle · guesses`.
+ *
+ * @param {ScoreboardStyle} style - The game's scoreboard style.
+ * @param {string} fallback_title - Title to use when the style does not name one.
+ */
+export function render_heading(
+  style: ScoreboardStyle,
+  fallback_title: string,
+): string {
+  const title = style.title ?? fallback_title;
+
+  return style.unit ? `${title} · ${style.unit}` : title;
+}
+
+/**
+ * Renders one scoreboard row per entry, e.g. ``🥇 `3/6` [Jørgen](…)``.
+ *
+ * `entries` must already be sorted best first - rank comes from position in the list, and entries
+ * showing the same score share a rank.
+ *
+ * Scores are padded to a common width inside inline code so they line up as a column. Inline code
+ * is the only monospace Discord offers that still renders a link next to it, and padding on the
+ * front only keeps the padding from being stripped as code fence padding.
+ *
+ * @param {GameEntry[]} entries - Today's entries for one game, best first.
+ * @param {ScoreboardStyle} style - How this game's scores are presented.
+ * @param {boolean} [links=true] - Whether names link to the message the score was shared in. The
+ * link is most of a row's length, so a summary too big for Discord gives these up - see
+ * `LAYOUT_PREFERENCES`.
+ * @returns {string[]} One rendered row per entry, in the same order.
+ */
+export function render_rows(
+  entries: GameEntry[],
+  style: ScoreboardStyle,
+  links: boolean = true,
+): string[] {
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const display = style.display ?? ((score: string) => score);
+  const scores = entries.map((entry) => display(entry.score));
+  const width = Math.max(...scores.map((score) => score.length));
+
+  let rank = 0;
+  let previous_score: string | undefined;
+
+  return entries.map((entry, index) => {
+    // Position in the list is the rank, except for entries showing the same score as the one above
+    // them, which keep that entry's rank.
+    if (scores[index] !== previous_score) {
+      rank = index + 1;
+      previous_score = scores[index];
+    }
+
+    const failed = style.is_failed?.(entry.score) ?? false;
+    const marker = failed
+      ? ` ${FAILED}`
+      : style.is_perfect?.(entry.score)
+        ? ` ${PERFECT}`
+        : '';
+
+    const score = `\`${scores[index].padStart(width)}\``;
+    const user = links ? render_user_link(entry) : render_user(entry);
+
+    return `${render_rank(rank, failed)} ${score} ${user}${marker}`;
+  });
+}
+
+/**
+ * Renders a rank as a medal, or as a plain number once the medals run out.
+ */
+function render_rank(rank: number, failed: boolean): string {
+  return !failed && rank <= MEDALS.length ? MEDALS[rank - 1] : `\`${rank}.\``;
+}
+
+/**
+ * Renders a player's name as a link to the message their score was shared in.
+ */
+function render_user_link(entry: GameEntry): string {
+  const message_url = `https://discord.com/channels/${entry.server_id}/${entry.channel_id}/${entry.message_id}`;
+
+  return `[${render_user(entry)}](${message_url})`;
+}
+
+/**
+ * Renders a player's name.
+ */
+function render_user(entry: GameEntry): string {
+  return entry.user.server_name ?? entry.user.name;
+}

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,7 +1,7 @@
-import { EmbedField, Message, TextChannel } from 'discord.js';
+import { Message, TextChannel } from 'discord.js';
 import { MessageParser } from './message_parser.js';
 import { GameEntry, GameEntryModel } from './database/schema.js';
-import { EmbedFieldFormatter } from './embeds/embed_formatter.js';
+import { EmbedFieldFormatter, Scoreboard } from './embeds/embed_formatter.js';
 import { summary_button_row } from './summary_button.js';
 import { get_today } from '../util.js';
 
@@ -92,15 +92,12 @@ export class Game {
   }
 
   /**
-   * Generates an Embed field with all of today's entries for this game.
+   * Loads and ranks all of today's entries for this game.
    *
-   * @param {boolean} [inline=true] - Whether the embed should be inline or not.
-   * @returns {Promise<EmbedField>} An embed field.
+   * @returns {Promise<Scoreboard | null>} The scoreboard, or `null` if nobody played today.
    */
-  public get_embed_field = async (
-    inline: boolean = true,
-  ): Promise<EmbedField | null> =>
-    await this.embed_field_formatter.get_embed_field(inline);
+  public load_scoreboard = async (): Promise<Scoreboard | null> =>
+    await this.embed_field_formatter.load();
 }
 
 export default Game;

--- a/src/games/bullpen.ts
+++ b/src/games/bullpen.ts
@@ -6,24 +6,14 @@ import { seconds_to_clock } from '../util.js';
 export const Description: string = `Daily games from Bullpen:
 Available on App store / Google play`;
 
-/** Burnt orange, after the app's icon. */
 export const Color: number = 0xe76f51;
 
-/**
- * Turns a shared solve time into seconds. Times under a minute are shared as `1.2s` and kept as
- * they are, since they carry a precision whole seconds would throw away.
- */
+/** Solve times are shared as `mm:ss`, or as `1.2s` when under a minute. */
 const parse_time = (score: string): string =>
   score.includes(':')
     ? String(Number(score.split(':')[0]) * 60 + Number(score.split(':')[1]))
     : score;
 
-/**
- * Renders a stored solve time as a clock, whether it was stored as whole seconds or as a shared
- * sub-minute time like `5.1s`. Both end up on the same scoreboard, so both have to read the same
- * way - the tenths a fast solve was shared with are kept, since they are what separates one from
- * the next.
- */
 const display_time = (score: string): string => {
   if (/^\d+$/.test(score)) {
     return seconds_to_clock(score);
@@ -34,9 +24,6 @@ const display_time = (score: string): string => {
   return isNaN(seconds) ? score : `0:${seconds.toFixed(1).padStart(4, '0')}`;
 };
 
-/**
- * Both difficulties are timed, and share a scoreboard style.
- */
 const bullpen_scoreboard = (title: string): ScoreboardStyle => ({
   title: title,
   unit: 'time',

--- a/src/games/bullpen.ts
+++ b/src/games/bullpen.ts
@@ -1,8 +1,47 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
+import { ScoreboardStyle } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
+import { seconds_to_clock } from '../util.js';
 
 export const Description: string = `Daily games from Bullpen:
 Available on App store / Google play`;
+
+/** Burnt orange, after the app's icon. */
+export const Color: number = 0xe76f51;
+
+/**
+ * Turns a shared solve time into seconds. Times under a minute are shared as `1.2s` and kept as
+ * they are, since they carry a precision whole seconds would throw away.
+ */
+const parse_time = (score: string): string =>
+  score.includes(':')
+    ? String(Number(score.split(':')[0]) * 60 + Number(score.split(':')[1]))
+    : score;
+
+/**
+ * Renders a stored solve time as a clock, whether it was stored as whole seconds or as a shared
+ * sub-minute time like `5.1s`. Both end up on the same scoreboard, so both have to read the same
+ * way - the tenths a fast solve was shared with are kept, since they are what separates one from
+ * the next.
+ */
+const display_time = (score: string): string => {
+  if (/^\d+$/.test(score)) {
+    return seconds_to_clock(score);
+  }
+
+  const seconds = parseFloat(score);
+
+  return isNaN(seconds) ? score : `0:${seconds.toFixed(1).padStart(4, '0')}`;
+};
+
+/**
+ * Both difficulties are timed, and share a scoreboard style.
+ */
+const bullpen_scoreboard = (title: string): ScoreboardStyle => ({
+  title: title,
+  unit: 'time',
+  display: display_time,
+});
 
 export const BullpenEasy = new GameBuilder('BullpenEasy')
   .add_message_parser(
@@ -11,23 +50,13 @@ export const BullpenEasy = new GameBuilder('BullpenEasy')
       /Bullpen — ([0-9]{1,2}\. [a-zæøå]+\. \d{4})\s*🌱 Lett: Løst på (?![Ii]ngen tid\.?$)((?:\d+(?::\d{2})?|\d+\.\ds))/,
       [MatchType.Day, MatchType.Score],
       (date) => date,
-      (score) =>
-        score.includes(":")
-          ? (String)((Number)(score.split(":")[0])*60 + (Number)(score.split(":")[1]))
-          : score
-    )
+      parse_time,
+    ),
   )
-  .set_matcher(
-    /Bullpen — ([0-9]{1,2}\. [a-zæøå]+\. \d{4})\s*🌱 Lett: Løst på (?![Ii]ngen tid\.?$)((?:\d+(?::\d{2})?|\d+\.\ds))/,
-    [MatchType.Day, MatchType.Score]
-  )
+  .set_scoreboard(bullpen_scoreboard('🌱 Lett'))
   .set_responder((entry) => {
     return `${entry.user.server_name ?? entry.user.name} did 🌱 Bullpen for ${entry.day_id} with score ${entry.score}.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link: any, score: any) =>
-      `${user_link} : ${score}`,
-  )
   .build();
 
 export const BullpenHard = new GameBuilder('BullpenHard')
@@ -37,18 +66,11 @@ export const BullpenHard = new GameBuilder('BullpenHard')
       /Bullpen — ([0-9]{1,2}\. [a-zæøå]+\. \d{4})[\s\S]*?🔥 Vanskelig: Løst på (?![Ii]ngen tid\.?$)((?:\d+(?::\d{2})?|\d+(?:\.\d+)?s))/,
       [MatchType.Day, MatchType.Score],
       (date) => date,
-      (score) =>
-        score.includes(":")
-          ? (String)((Number)(score.split(":")[0])*60 + (Number)(score.split(":")[1]))
-          : score
-    )
+      parse_time,
+    ),
   )
+  .set_scoreboard(bullpen_scoreboard('🔥 Vanskelig'))
   .set_responder((entry) => {
     return `${entry.user.server_name ?? entry.user.name} did 🔥 Bullpen for ${entry.day_id} with score ${entry.score}.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link: any, score: any) =>
-      `${user_link} : ${score}`,
-  )
   .build();
-

--- a/src/games/bybandle.ts
+++ b/src/games/bybandle.ts
@@ -6,6 +6,11 @@ export const Bybandle = new GameBuilder('Bybandle')
     MatchType.Day,
     MatchType.Score,
   ])
+  .set_scoreboard({
+    unit: 'guesses',
+    is_perfect: (score) => score.startsWith('1/'),
+    is_failed: (score) => score.startsWith('X'),
+  })
   .set_responder((entry) => {
     const user = entry.user.server_name ?? entry.user.name;
     if (entry.score.startsWith('X')) {
@@ -17,3 +22,6 @@ export const Bybandle = new GameBuilder('Bybandle')
 
 export const Description: string = `Guess today's Bergen light rail jingle:
 [Bybandle](https://bybandle-production.up.railway.app)`;
+
+/** Bybanen blue. */
+export const Color: number = 0x005aa7;

--- a/src/games/bybandle.ts
+++ b/src/games/bybandle.ts
@@ -23,5 +23,4 @@ export const Bybandle = new GameBuilder('Bybandle')
 export const Description: string = `Guess today's Bergen light rail jingle:
 [Bybandle](https://bybandle-production.up.railway.app)`;
 
-/** Bybanen blue. */
 export const Color: number = 0x005aa7;

--- a/src/games/foodguessr.ts
+++ b/src/games/foodguessr.ts
@@ -1,5 +1,9 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
+import { highest_first } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
+
+/** Plates in a daily Plate-Off. */
+const FOODGUESSR_PLATES = 10;
 
 export const FoodGuessr = new GameBuilder('FoodGuessr')
   .add_message_parser(
@@ -11,14 +15,22 @@ export const FoodGuessr = new GameBuilder('FoodGuessr')
       (score) => score.trim(),
     ),
   )
+  // Scored on plates guessed right, so the biggest number wins.
+  .set_score_sorter(highest_first())
+  .set_scoreboard({
+    unit: 'correct',
+    display: (score) => `${score}/${FOODGUESSR_PLATES}`,
+    is_perfect: (score) => Number(score) === FOODGUESSR_PLATES,
+  })
   .set_responder((entry) => {
-    return entry.score === "10" ? `⭐ ${entry.user.server_name ?? entry.user.name} achieved a perfect score on FoodGuessr! ⭐`
+    return entry.score === '10'
+      ? `⭐ ${entry.user.server_name ?? entry.user.name} achieved a perfect score on FoodGuessr! ⭐`
       : `${entry.user.server_name ?? entry.user.name} did FoodGuessr with score ${entry.score}/10.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link, score) => `${user_link}: ${score}/10`,
-  )
   .build();
 
 export const Description: string = `Daily FoodGuessr Plate-Off game:
 [Play FoodGuessr](https://www.foodguessr.com/game/plate-off/daily)`;
+
+/** Warm red, after the site's branding. */
+export const Color: number = 0xef476f;

--- a/src/games/foodguessr.ts
+++ b/src/games/foodguessr.ts
@@ -2,7 +2,6 @@ import { GameBuilder } from '../core/builders/game_builder.js';
 import { highest_first } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
 
-/** Plates in a daily Plate-Off. */
 const FOODGUESSR_PLATES = 10;
 
 export const FoodGuessr = new GameBuilder('FoodGuessr')
@@ -15,7 +14,6 @@ export const FoodGuessr = new GameBuilder('FoodGuessr')
       (score) => score.trim(),
     ),
   )
-  // Scored on plates guessed right, so the biggest number wins.
   .set_score_sorter(highest_first())
   .set_scoreboard({
     unit: 'correct',
@@ -32,5 +30,4 @@ export const FoodGuessr = new GameBuilder('FoodGuessr')
 export const Description: string = `Daily FoodGuessr Plate-Off game:
 [Play FoodGuessr](https://www.foodguessr.com/game/plate-off/daily)`;
 
-/** Warm red, after the site's branding. */
 export const Color: number = 0xef476f;

--- a/src/games/foodguessr.ts
+++ b/src/games/foodguessr.ts
@@ -21,9 +21,9 @@ export const FoodGuessr = new GameBuilder('FoodGuessr')
     is_perfect: (score) => Number(score) === FOODGUESSR_PLATES,
   })
   .set_responder((entry) => {
-    return entry.score === '10'
+    return Number(entry.score) === FOODGUESSR_PLATES
       ? `⭐ ${entry.user.server_name ?? entry.user.name} achieved a perfect score on FoodGuessr! ⭐`
-      : `${entry.user.server_name ?? entry.user.name} did FoodGuessr with score ${entry.score}/10.`;
+      : `${entry.user.server_name ?? entry.user.name} did FoodGuessr with score ${entry.score}/${FOODGUESSR_PLATES}.`;
   })
   .build();
 

--- a/src/games/fourbythree.ts
+++ b/src/games/fourbythree.ts
@@ -1,5 +1,5 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
-import { ScoreSorter } from '../core/embeds/embed_formatter.js';
+import { highest_first } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
 
 /**
@@ -65,13 +65,6 @@ const parse_score = (summary: string): string => {
 const points_of = (score: string): string => score.split(',')[0];
 const mistakes_of = (score: string): string => score.split(',')[1];
 
-/** Sorts on points, descending, with unsolved puzzles last. */
-const SCORE_SORTER: ScoreSorter = (a, b) => {
-  const x = parseInt(a.score);
-  const y = parseInt(b.score);
-  return isNaN(x) ? 1 : isNaN(y) ? -1 : y - x;
-};
-
 export const FourByThree = new GameBuilder('4x3')
   .add_message_parser(
     new MessageParser(
@@ -82,7 +75,16 @@ export const FourByThree = new GameBuilder('4x3')
       parse_score,
     ),
   )
-  .set_score_sorter(SCORE_SORTER)
+  // Scored on points, so the biggest number wins. An unsolved puzzle scores `X` and ranks last.
+  .set_score_sorter(highest_first())
+  .set_scoreboard({
+    unit: 'points',
+    display: points_of,
+    is_perfect: (score) =>
+      points_of(score) !== NO_POINTS && mistakes_of(score) === '0',
+    is_failed: (score) =>
+      points_of(score) === NO_POINTS || mistakes_of(score) === RULE_BREAKER,
+  })
   .set_responder((entry) => {
     const user = entry.user.server_name ?? entry.user.name;
     const points = points_of(entry.score);
@@ -99,10 +101,10 @@ export const FourByThree = new GameBuilder('4x3')
     }
     return `${user} did 4x3 ${entry.day_id} with ${points} points and ${mistakes} mistake${mistakes === '1' ? '' : 's'}`;
   })
-  .set_embed_field_score_formatter(
-    (user_link, score) => `${user_link} : ${points_of(score)}`,
-  )
   .build();
 
 export const Description: string = `Daily 4x3 puzzle by Hank Green:
 [Play 4x3](https://4x3.fun/)`;
+
+/** Gold, after the 🌟 shared word. */
+export const Color: number = 0xfacc15;

--- a/src/games/fourbythree.ts
+++ b/src/games/fourbythree.ts
@@ -75,7 +75,6 @@ export const FourByThree = new GameBuilder('4x3')
       parse_score,
     ),
   )
-  // Scored on points, so the biggest number wins. An unsolved puzzle scores `X` and ranks last.
   .set_score_sorter(highest_first())
   .set_scoreboard({
     unit: 'points',
@@ -106,5 +105,4 @@ export const FourByThree = new GameBuilder('4x3')
 export const Description: string = `Daily 4x3 puzzle by Hank Green:
 [Play 4x3](https://4x3.fun/)`;
 
-/** Gold, after the 🌟 shared word. */
 export const Color: number = 0xfacc15;

--- a/src/games/gamedle.ts
+++ b/src/games/gamedle.ts
@@ -14,10 +14,7 @@ function gamedle_score_parser(max_attempts: number): MatchParser {
       .toString();
 }
 
-/**
- * Every Gamedle mode counts guesses against a cap, and a score at the cap means the game was never
- * guessed. Modes are titled without the `Gamedle` prefix, which the embed around them already says.
- */
+/** A score at the cap means the game was never guessed. */
 function gamedle_scoreboard(
   title: string,
   max_attempts: number,
@@ -82,5 +79,4 @@ export const Description: string = `Daily games from Gamedle:
 [Keywords](https://www.gamedle.wtf/keywords) | \
 [Guess](https://www.gamedle.wtf/guess)`;
 
-/** Purple, after the site's header. */
 export const Color: number = 0x9b5de5;

--- a/src/games/gamedle.ts
+++ b/src/games/gamedle.ts
@@ -1,5 +1,5 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
-import { ScoreFormatter, ScoreSorter } from '../core/embeds/embed_formatter.js';
+import { ScoreboardStyle } from '../core/embeds/scoreboard.js';
 import { Responder } from '../core/game.js';
 import { MatchParser, MatchType } from '../core/message_parser.js';
 
@@ -14,9 +14,21 @@ function gamedle_score_parser(max_attempts: number): MatchParser {
       .toString();
 }
 
-function gamedle_score_formatter(max_attempts: number): ScoreFormatter {
-  return (user_link: any, score: any) =>
-    `${user_link} : ${score === '1' ? '🌟' : Number(score) < max_attempts ? score : '💀'}`;
+/**
+ * Every Gamedle mode counts guesses against a cap, and a score at the cap means the game was never
+ * guessed. Modes are titled without the `Gamedle` prefix, which the embed around them already says.
+ */
+function gamedle_scoreboard(
+  title: string,
+  max_attempts: number,
+): ScoreboardStyle {
+  return {
+    title: title,
+    unit: 'guesses',
+    display: (score) => `${score}/${max_attempts}`,
+    is_perfect: (score) => score === '1',
+    is_failed: (score) => Number(score) >= max_attempts,
+  };
 }
 
 function gamedle_responder(max_attempts: number): Responder {
@@ -24,17 +36,13 @@ function gamedle_responder(max_attempts: number): Responder {
     `${entry.user.server_name ?? entry.user.name} ${Number(entry.score) < max_attempts ? 'did' : 'failed'} ${entry.game} with ${entry.score} attempts.`;
 }
 
-const score_sorter: ScoreSorter = (a: any, b: any) => Number(a.score) - Number(b.score);
-
 export const Classic = new GameBuilder('Gamedle (Classic)')
   .set_matcher(/Gamedle:\s(\d{2}\/\d{2}\/\d{4})\s(.*)\s?>/, [
     MatchType.Day,
     MatchType.Score,
   ])
   .set_score_parser(gamedle_score_parser(GAMEDLE_DEFAULT_ATTEMPTS))
-  .set_embed_field_score_formatter(
-    gamedle_score_formatter(GAMEDLE_DEFAULT_ATTEMPTS),
-  )
+  .set_scoreboard(gamedle_scoreboard('Classic', GAMEDLE_DEFAULT_ATTEMPTS))
   .set_responder(gamedle_responder(GAMEDLE_DEFAULT_ATTEMPTS))
   .build();
 
@@ -44,9 +52,7 @@ export const Artwork = new GameBuilder('Gamedle (Artwork)')
     MatchType.Score,
   ])
   .set_score_parser(gamedle_score_parser(GAMEDLE_DEFAULT_ATTEMPTS))
-  .set_embed_field_score_formatter(
-    gamedle_score_formatter(GAMEDLE_DEFAULT_ATTEMPTS),
-  )
+  .set_scoreboard(gamedle_scoreboard('Artwork', GAMEDLE_DEFAULT_ATTEMPTS))
   .set_responder(gamedle_responder(GAMEDLE_DEFAULT_ATTEMPTS))
   .build();
 
@@ -56,9 +62,7 @@ export const Keywords = new GameBuilder('Gamedle (Keywords)')
     MatchType.Score,
   ])
   .set_score_parser(gamedle_score_parser(GAMEDLE_DEFAULT_ATTEMPTS))
-  .set_embed_field_score_formatter(
-    gamedle_score_formatter(GAMEDLE_DEFAULT_ATTEMPTS),
-  )
+  .set_scoreboard(gamedle_scoreboard('Keywords', GAMEDLE_DEFAULT_ATTEMPTS))
   .set_responder(gamedle_responder(GAMEDLE_DEFAULT_ATTEMPTS))
   .build();
 
@@ -68,9 +72,7 @@ export const Guess = new GameBuilder('Gamedle (Guess)')
     MatchType.Score,
   ])
   .set_score_parser(gamedle_score_parser(GAMEDLE_GUESS_ATTEMPTS))
-  .set_embed_field_score_formatter(
-    gamedle_score_formatter(GAMEDLE_GUESS_ATTEMPTS),
-  )
+  .set_scoreboard(gamedle_scoreboard('Guess', GAMEDLE_GUESS_ATTEMPTS))
   .set_responder(gamedle_responder(GAMEDLE_GUESS_ATTEMPTS))
   .build();
 
@@ -79,3 +81,6 @@ export const Description: string = `Daily games from Gamedle:
 [Artwork](https://www.gamedle.wtf/artwork) | \
 [Keywords](https://www.gamedle.wtf/keywords) | \
 [Guess](https://www.gamedle.wtf/guess)`;
+
+/** Purple, after the site's header. */
+export const Color: number = 0x9b5de5;

--- a/src/games/globle.ts
+++ b/src/games/globle.ts
@@ -1,7 +1,18 @@
-import { GameBuilder } from '../core/builders/game_builder.js'
+import { GameBuilder } from '../core/builders/game_builder.js';
+import { ScoreboardStyle } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
 
-export const Globle = new GameBuilder('Globle') 
+/**
+ * Both Globles are won by naming the country in as few guesses as possible, and getting it on the
+ * first guess is a genuine fluke worth marking.
+ */
+const globle_scoreboard = (title: string): ScoreboardStyle => ({
+  title: title,
+  unit: 'guesses',
+  is_perfect: (score) => score === '1',
+});
+
+export const Globle = new GameBuilder('Globle')
   .add_message_parser(
     new MessageParser(
       'Globle',
@@ -11,16 +22,13 @@ export const Globle = new GameBuilder('Globle')
       (match) => match,
     ),
   )
+  .set_scoreboard(globle_scoreboard('Globle'))
   .set_responder((entry) => {
     return `${entry.user.server_name ?? entry.user.name} did Globle for ${entry.day_id} with score ${entry.score}.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link, score) => 
-      `${user_link} : ${score}`,
-  )
   .build();
 
-  export const GlobleCapitals = new GameBuilder('GlobleCapitals') 
+export const GlobleCapitals = new GameBuilder('GlobleCapitals')
   .add_message_parser(
     new MessageParser(
       'GlobleCapitals',
@@ -30,16 +38,15 @@ export const Globle = new GameBuilder('Globle')
       (match) => match,
     ),
   )
+  .set_scoreboard(globle_scoreboard('Capitals'))
   .set_responder((entry) => {
     return `${entry.user.server_name ?? entry.user.name} did Globle (capitals) for ${entry.day_id} with score ${entry.score}.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link, score) => 
-      `${user_link} : ${score}`,
-  )
   .build();
 
-  export const Description: string = `Daily games from Globle:
-  [Globle](https://globle-game.com/) | \
-  [Globle Capitals](https://globle-capitals.com/)`;
-  
+export const Description: string = `Daily games from Globle:
+[Globle](https://globle-game.com/) | \
+[Globle Capitals](https://globle-capitals.com/)`;
+
+/** Teal, after the site's ocean. */
+export const Color: number = 0x14b8a6;

--- a/src/games/globle.ts
+++ b/src/games/globle.ts
@@ -2,10 +2,6 @@ import { GameBuilder } from '../core/builders/game_builder.js';
 import { ScoreboardStyle } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
 
-/**
- * Both Globles are won by naming the country in as few guesses as possible, and getting it on the
- * first guess is a genuine fluke worth marking.
- */
 const globle_scoreboard = (title: string): ScoreboardStyle => ({
   title: title,
   unit: 'guesses',
@@ -48,5 +44,4 @@ export const Description: string = `Daily games from Globle:
 [Globle](https://globle-game.com/) | \
 [Globle Capitals](https://globle-capitals.com/)`;
 
-/** Teal, after the site's ocean. */
 export const Color: number = 0x14b8a6;

--- a/src/games/new_york_times.ts
+++ b/src/games/new_york_times.ts
@@ -18,9 +18,6 @@ export const Wordle = new GameBuilder('Wordle')
   )
   .build();
 
-/**
- * Connections is scored on mistakes made, and allows four of them before the puzzle is lost.
- */
 const CONNECTIONS_MISTAKES_ALLOWED = 4;
 
 export const Connections = new GameBuilder('Connections')
@@ -95,9 +92,7 @@ export const TheMini = new GameBuilder('The Mini')
   )
   .build();
 
-/**
- * Strands scores are stored as `<hints>,<words found unaided>,<words found>`.
- */
+/** Strands scores are stored as `<hints>,<words found unaided>,<words found>`. */
 const hints_of = (score: string): string => score.split(',')[0];
 
 export const Strands = new GameBuilder('Strands')
@@ -113,8 +108,6 @@ export const Strands = new GameBuilder('Strands')
     return `${hints},${words - hints},${words}`;
   })
   .set_scoreboard({
-    // Everyone who finishes Strands finds every word, so hints used is the only thing that ranks
-    // one solve above another.
     unit: 'hints',
     display: hints_of,
     is_perfect: (score) => hints_of(score) === '0',
@@ -134,5 +127,4 @@ export const Description: string = `Daily games from the New York Times:
 [Mini Crossword](https://www.nytimes.com/crosswords/game/mini) | \
 [Strands](https://www.nytimes.com/games/strands)`;
 
-/** Wordle green. */
 export const Color: number = 0x6aaa64;

--- a/src/games/new_york_times.ts
+++ b/src/games/new_york_times.ts
@@ -1,17 +1,27 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
-import { seconds_to_display_time } from '../util.js';
+import { seconds_to_clock, seconds_to_display_time } from '../util.js';
 
 export const Wordle = new GameBuilder('Wordle')
   .set_matcher(/Wordle (\d+\s?,?\d+) ([1-6X]\/6)/, [
     MatchType.Day,
     MatchType.Score,
   ])
+  .set_scoreboard({
+    unit: 'guesses',
+    is_perfect: (score) => score.startsWith('1/'),
+    is_failed: (score) => score.startsWith('X'),
+  })
   .set_responder(
     (entry) =>
       `${entry.user.server_name ?? entry.user.name} scored ${entry.score} on Wordle ${entry.day_id}`,
   )
   .build();
+
+/**
+ * Connections is scored on mistakes made, and allows four of them before the puzzle is lost.
+ */
+const CONNECTIONS_MISTAKES_ALLOWED = 4;
 
 export const Connections = new GameBuilder('Connections')
   .set_matcher(/Connections\sPuzzle\s#(\d+)\s([🟩🟨🟦🟪\s]+)/u, [
@@ -36,6 +46,11 @@ export const Connections = new GameBuilder('Connections')
       )
       .toString(),
   )
+  .set_scoreboard({
+    unit: 'mistakes',
+    is_perfect: (score) => score === '0',
+    is_failed: (score) => Number(score) >= CONNECTIONS_MISTAKES_ALLOWED,
+  })
   .set_responder(
     (entry) =>
       `${entry.user.server_name ?? entry.user.name} ${Number(entry.score) < 4 ? 'did' : 'failed'} Connections ${entry.day_id} ${Number(entry.score) < 4 ? 'with' : 'after'} ${entry.score == '0' ? 'no' : entry.score} mistakes`,
@@ -70,14 +85,20 @@ export const TheMini = new GameBuilder('The Mini')
       },
     ),
   )
+  .set_scoreboard({
+    unit: 'time',
+    display: seconds_to_clock,
+  })
   .set_responder(
     (entry) =>
       `${entry.user.server_name ?? entry.user.name} did The Mini in ${seconds_to_display_time(entry.score)}`,
   )
-  .set_embed_field_score_formatter(
-    (user_link: any, score: any) => `${user_link} : ${seconds_to_display_time(score)}`,
-  )
   .build();
+
+/**
+ * Strands scores are stored as `<hints>,<words found unaided>,<words found>`.
+ */
+const hints_of = (score: string): string => score.split(',')[0];
 
 export const Strands = new GameBuilder('Strands')
   .set_matcher(/Strands\s(#\d+)\s“.*”\s([💡🔵🟡\s]+)/u, [
@@ -91,17 +112,20 @@ export const Strands = new GameBuilder('Strands')
 
     return `${hints},${words - hints},${words}`;
   })
+  .set_scoreboard({
+    // Everyone who finishes Strands finds every word, so hints used is the only thing that ranks
+    // one solve above another.
+    unit: 'hints',
+    display: hints_of,
+    is_perfect: (score) => hints_of(score) === '0',
+  })
   .set_responder((entry) => {
-    const hints = entry.score.split(',')[0];
+    const hints = hints_of(entry.score);
     if (hints == '0') {
       return `${entry.user.server_name ?? entry.user.name} got ✨perfect✨ on Strands ${entry.day_id}`;
     }
     return `${entry.user.server_name ?? entry.user.name} did Strands ${entry.day_id} with ${hints} hints`;
   })
-  .set_embed_field_score_formatter(
-    (user_link: any, score: any) =>
-      `${user_link} : ${score.split(',').slice(1).join('/')}`,
-  )
   .build();
 
 export const Description: string = `Daily games from the New York Times:
@@ -109,3 +133,6 @@ export const Description: string = `Daily games from the New York Times:
 [Connections](https://www.nytimes.com/games/connections) | \
 [Mini Crossword](https://www.nytimes.com/crosswords/game/mini) | \
 [Strands](https://www.nytimes.com/games/strands)`;
+
+/** Wordle green. */
+export const Color: number = 0x6aaa64;

--- a/src/games/new_york_times.ts
+++ b/src/games/new_york_times.ts
@@ -48,10 +48,10 @@ export const Connections = new GameBuilder('Connections')
     is_perfect: (score) => score === '0',
     is_failed: (score) => Number(score) >= CONNECTIONS_MISTAKES_ALLOWED,
   })
-  .set_responder(
-    (entry) =>
-      `${entry.user.server_name ?? entry.user.name} ${Number(entry.score) < 4 ? 'did' : 'failed'} Connections ${entry.day_id} ${Number(entry.score) < 4 ? 'with' : 'after'} ${entry.score == '0' ? 'no' : entry.score} mistakes`,
-  )
+  .set_responder((entry) => {
+    const solved = Number(entry.score) < CONNECTIONS_MISTAKES_ALLOWED;
+    return `${entry.user.server_name ?? entry.user.name} ${solved ? 'did' : 'failed'} Connections ${entry.day_id} ${solved ? 'with' : 'after'} ${entry.score == '0' ? 'no' : entry.score} mistakes`;
+  })
   .build();
 
 export const TheMini = new GameBuilder('The Mini')

--- a/src/games/nrk.ts
+++ b/src/games/nrk.ts
@@ -12,7 +12,6 @@ export const Tvers = new GameBuilder('Tvers')
       (match) => match,
     ),
   )
-  // Tvers awards points, so unlike most games here the biggest number wins.
   .set_score_sorter(highest_first())
   .set_scoreboard({ unit: 'points' })
   .set_responder((entry) => {
@@ -40,5 +39,4 @@ export const Description: string = `Daily games from NRK:
 [Tvers](https://www.nrk.no/spill/tvers) | \
 [Former](https://www.nrk.no/spill/former)`;
 
-/** NRK blue. */
 export const Color: number = 0x00b9f1;

--- a/src/games/nrk.ts
+++ b/src/games/nrk.ts
@@ -1,8 +1,8 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
+import { highest_first } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
 
-
-export const Tvers = new GameBuilder('Tvers') 
+export const Tvers = new GameBuilder('Tvers')
   .add_message_parser(
     new MessageParser(
       'Tvers',
@@ -12,13 +12,12 @@ export const Tvers = new GameBuilder('Tvers')
       (match) => match,
     ),
   )
+  // Tvers awards points, so unlike most games here the biggest number wins.
+  .set_score_sorter(highest_first())
+  .set_scoreboard({ unit: 'points' })
   .set_responder((entry) => {
     return `${entry.user.server_name ?? entry.user.name} did Tvers ${entry.day_id} with score ${entry.score}.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link: any, score: any) => 
-      `${user_link} : ${score}`,
-  )
   .build();
 
 export const Former = new GameBuilder('Former')
@@ -31,17 +30,15 @@ export const Former = new GameBuilder('Former')
       (match) => match,
     ),
   )
+  .set_scoreboard({ unit: 'moves' })
   .set_responder((entry) => {
-    console.log('have entry: ', entry)
-    const d = new Date();
     return `${entry.user.server_name ?? entry.user.name} did Former ${entry.day_id} in ${entry.score} moves.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link: any, score: any) => 
-      `${user_link} : ${score}`,
-  )
   .build();
 
-export const Description: string = `Daily games from Norsk Rikskringkasting (NRK):
+export const Description: string = `Daily games from NRK:
 [Tvers](https://www.nrk.no/spill/tvers) | \
 [Former](https://www.nrk.no/spill/former)`;
+
+/** NRK blue. */
+export const Color: number = 0x00b9f1;

--- a/src/games/timeguessr.ts
+++ b/src/games/timeguessr.ts
@@ -6,6 +6,8 @@ const TIMEGUESSR_MAX_POINTS = 50_000;
 
 const TIMEGUESSR_GREAT_SCORE = 45_000;
 
+const TIMEGUESSR_GOOD_SCORE = 40_000;
+
 export const TimeGuessr = new GameBuilder('TimeGuessr')
   .add_message_parser(
     new MessageParser(
@@ -22,14 +24,18 @@ export const TimeGuessr = new GameBuilder('TimeGuessr')
     is_perfect: (score) => numeric(score) >= TIMEGUESSR_GREAT_SCORE,
   })
   .set_responder((entry) => {
-    const parsedScore = Number.parseInt(entry.score.split(',')[0]);
-    if (parsedScore > 40) {
-      if (parsedScore >= 45) {
-        return `⭐ ${entry.user.server_name ?? entry.user.name} did TimeGuessr #${entry.day_id} with score ${entry.score} ⭐`;
-      }
-      return `${entry.user.server_name ?? entry.user.name} did TimeGuessr #${entry.day_id} with score ${entry.score} 🔥`;
+    // `numeric` reads the score through its thousands separator - `parseInt` alone would take
+    // `44,123` as 44, and a sub-1000 score as a number in the tens of thousands.
+    const points = numeric(entry.score);
+    const user = entry.user.server_name ?? entry.user.name;
+
+    if (points >= TIMEGUESSR_GREAT_SCORE) {
+      return `⭐ ${user} did TimeGuessr #${entry.day_id} with score ${entry.score} ⭐`;
     }
-    return `${entry.user.server_name ?? entry.user.name} did TimeGuessr #${entry.day_id} with score ${entry.score}.`;
+    if (points >= TIMEGUESSR_GOOD_SCORE) {
+      return `${user} did TimeGuessr #${entry.day_id} with score ${entry.score} 🔥`;
+    }
+    return `${user} did TimeGuessr #${entry.day_id} with score ${entry.score}.`;
   })
   .build();
 

--- a/src/games/timeguessr.ts
+++ b/src/games/timeguessr.ts
@@ -1,5 +1,12 @@
 import { GameBuilder } from '../core/builders/game_builder.js';
+import { highest_first, numeric } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
+
+/** Points on offer across a daily round. */
+const TIMEGUESSR_MAX_POINTS = 50_000;
+
+/** From here up, a round went well enough to be worth marking. */
+const TIMEGUESSR_GREAT_SCORE = 45_000;
 
 export const TimeGuessr = new GameBuilder('TimeGuessr')
   .add_message_parser(
@@ -11,8 +18,16 @@ export const TimeGuessr = new GameBuilder('TimeGuessr')
       (score) => score.trim(),
     ),
   )
+  // Scored on points, so the biggest number wins. Scores are stored with their thousands separator,
+  // which `numeric` reads through.
+  .set_score_sorter(highest_first())
+  .set_scoreboard({
+    // The maximum belongs in the heading rather than repeated on every row.
+    unit: `points / ${TIMEGUESSR_MAX_POINTS.toLocaleString('en-GB')}`,
+    is_perfect: (score) => numeric(score) >= TIMEGUESSR_GREAT_SCORE,
+  })
   .set_responder((entry) => {
-    const parsedScore = Number.parseInt(entry.score.split(",")[0]);
+    const parsedScore = Number.parseInt(entry.score.split(',')[0]);
     if (parsedScore > 40) {
       if (parsedScore >= 45) {
         return `⭐ ${entry.user.server_name ?? entry.user.name} did TimeGuessr #${entry.day_id} with score ${entry.score} ⭐`;
@@ -21,10 +36,10 @@ export const TimeGuessr = new GameBuilder('TimeGuessr')
     }
     return `${entry.user.server_name ?? entry.user.name} did TimeGuessr #${entry.day_id} with score ${entry.score}.`;
   })
-  .set_embed_field_score_formatter(
-    (user_link, score) => `${user_link}: ${score}/50000`,
-  )
   .build();
 
 export const Description: string = `Play today's TimeGuessr game:
 [TimeGuessr](https://timeguessr.com)`;
+
+/** Sepia, for a game about old photographs. */
+export const Color: number = 0xc08552;

--- a/src/games/timeguessr.ts
+++ b/src/games/timeguessr.ts
@@ -2,10 +2,8 @@ import { GameBuilder } from '../core/builders/game_builder.js';
 import { highest_first, numeric } from '../core/embeds/scoreboard.js';
 import { MatchType, MessageParser } from '../core/message_parser.js';
 
-/** Points on offer across a daily round. */
 const TIMEGUESSR_MAX_POINTS = 50_000;
 
-/** From here up, a round went well enough to be worth marking. */
 const TIMEGUESSR_GREAT_SCORE = 45_000;
 
 export const TimeGuessr = new GameBuilder('TimeGuessr')
@@ -18,11 +16,8 @@ export const TimeGuessr = new GameBuilder('TimeGuessr')
       (score) => score.trim(),
     ),
   )
-  // Scored on points, so the biggest number wins. Scores are stored with their thousands separator,
-  // which `numeric` reads through.
   .set_score_sorter(highest_first())
   .set_scoreboard({
-    // The maximum belongs in the heading rather than repeated on every row.
     unit: `points / ${TIMEGUESSR_MAX_POINTS.toLocaleString('en-GB')}`,
     is_perfect: (score) => numeric(score) >= TIMEGUESSR_GREAT_SCORE,
   })

--- a/src/test/generate_mock_data.ts
+++ b/src/test/generate_mock_data.ts
@@ -7,23 +7,15 @@ interface DbEntry extends GameEntry {
   updatedAt?: Date;
 }
 
-/**
- * Days of history to generate, so `/weekly` has something to chart.
- */
+/** Days of history to generate, so `/weekly` has something to chart. */
 const DAYS = 7;
 
-/**
- * Share of games a mock user skips on a given day.
- */
+/** Share of games a mock user skips on a given day. */
 const SKIP_RATE = 0.1;
 
 /**
- * A game to generate entries for.
- *
- * `name` has to be the name entries are stored under - which is the name of the message parser that
- * would have matched a real result, not always the name of the game - or the summary will not find
- * them. `score` has to produce the same shape that parser stores, since that is what the
- * scoreboards are written against.
+ * `name` has to be the name entries are stored under - the name of the message parser that would
+ * have matched a real result, not always the name of the game - or the summary will not find them.
  */
 interface MockGame {
   name: string;
@@ -31,37 +23,25 @@ interface MockGame {
   day_id?: (date: Date) => string;
 }
 
-/**
- * Picks a random integer in `[min, max]`.
- */
+/** Picks a random integer in `[min, max]`. */
 const between = (min: number, max: number): number =>
   min + Math.floor(Math.random() * (max - min + 1));
 
-/**
- * Picks one of `values` at random.
- */
+/** Picks one of `values` at random. */
 const one_of = <T>(...values: T[]): T => values[between(0, values.length - 1)];
 
-/**
- * Rolls a `1/max` .. `max/max` score that fails `fail_rate` of the time, as Wordle and Bybandle
- * store them.
- */
+/** Rolls a `1/max` .. `max/max` score, failing `fail_rate` of the time. */
 const guesses_out_of = (max: number, fail_rate: number) => (): string =>
   Math.random() < fail_rate ? `X/${max}` : `${between(1, max)}/${max}`;
 
 const iso_date = (date: Date): string => date.toISOString().slice(0, 10);
 
-/**
- * Mints a Discord-shaped ID. Snowflakes are 19 digits, and mock IDs have to be the same length as
- * the real thing for the summary's character budget to behave the way it will in production.
- */
+/** 19 digits, like a real snowflake, so message links are a realistic length. */
 const snowflake = (): Snowflake =>
   String(between(1, 9)) +
   Array.from({ length: 18 }, () => between(0, 9)).join('');
 
-/**
- * Every game the bot tracks, so a mock run exercises all of the scoreboards at once.
- */
+/** Every game the bot tracks, so a mock run exercises all of the scoreboards. */
 const GAMES: MockGame[] = [
   { name: 'Wordle', score: guesses_out_of(6, 0.08) },
   { name: 'Connections', score: () => String(between(0, 4)) },
@@ -111,9 +91,7 @@ const GAMES: MockGame[] = [
   },
 ];
 
-/**
- * Puzzle numbers to count up from, for the games that identify a day by one.
- */
+/** Puzzle numbers to count up from, for the games that identify a day by one. */
 const BASE_DAY_IDS: Record<string, number> = {
   Wordle: 1351,
   Connections: 629,

--- a/src/test/generate_mock_data.ts
+++ b/src/test/generate_mock_data.ts
@@ -139,7 +139,8 @@ export async function generate_mock_data() {
       : Array.from({ length: 5 }, (_, i) => ({
           id: snowflake(),
           name: `TestUser${i + 1}`,
-          server_name: `User${i + 1}`,
+          // Marked so an invented score is never mistaken for somebody's real result.
+          server_name: `[mock] User${i + 1}`,
         }));
 
   const entries: DbEntry[] = [];

--- a/src/test/generate_mock_data.ts
+++ b/src/test/generate_mock_data.ts
@@ -110,11 +110,12 @@ export async function generate_mock_data() {
     createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) },
   });
 
-  // Take 5 random active users or create mock users if none exist
+  // Take 5 random active users, or create mock users if none exist - enough of them to push a
+  // scoreboard past its 10 rows, so the `+ N more` trimming is exercised too.
   const selectedUsers =
     activeUsers.length > 0
       ? activeUsers.sort(() => 0.5 - Math.random()).slice(0, 5)
-      : Array.from({ length: 5 }, (_, i) => ({
+      : Array.from({ length: 12 }, (_, i) => ({
           id: snowflake(),
           name: `TestUser${i + 1}`,
           // Marked so an invented score is never mistaken for somebody's real result.

--- a/src/test/generate_mock_data.ts
+++ b/src/test/generate_mock_data.ts
@@ -1,176 +1,265 @@
 import { Snowflake } from 'discord.js';
-import { writeFileSync } from 'fs';
 import { GameEntryModel, GameEntry } from '../core/database/schema.js';
 import crypto from 'node:crypto';
-import fs from 'node:fs'; // Add this import at the top
 
 interface DbEntry extends GameEntry {
-    createdAt?: Date;
-    updatedAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
+
+/**
+ * Days of history to generate, so `/weekly` has something to chart.
+ */
+const DAYS = 7;
+
+/**
+ * Share of games a mock user skips on a given day.
+ */
+const SKIP_RATE = 0.1;
+
+/**
+ * A game to generate entries for.
+ *
+ * `name` has to be the name entries are stored under - which is the name of the message parser that
+ * would have matched a real result, not always the name of the game - or the summary will not find
+ * them. `score` has to produce the same shape that parser stores, since that is what the
+ * scoreboards are written against.
+ */
+interface MockGame {
+  name: string;
+  score: () => string;
+  day_id?: (date: Date) => string;
+}
+
+/**
+ * Picks a random integer in `[min, max]`.
+ */
+const between = (min: number, max: number): number =>
+  min + Math.floor(Math.random() * (max - min + 1));
+
+/**
+ * Picks one of `values` at random.
+ */
+const one_of = <T>(...values: T[]): T => values[between(0, values.length - 1)];
+
+/**
+ * Rolls a `1/max` .. `max/max` score that fails `fail_rate` of the time, as Wordle and Bybandle
+ * store them.
+ */
+const guesses_out_of = (max: number, fail_rate: number) => (): string =>
+  Math.random() < fail_rate ? `X/${max}` : `${between(1, max)}/${max}`;
+
+const iso_date = (date: Date): string => date.toISOString().slice(0, 10);
+
+/**
+ * Mints a Discord-shaped ID. Snowflakes are 19 digits, and mock IDs have to be the same length as
+ * the real thing for the summary's character budget to behave the way it will in production.
+ */
+const snowflake = (): Snowflake =>
+  String(between(1, 9)) +
+  Array.from({ length: 18 }, () => between(0, 9)).join('');
+
+/**
+ * Every game the bot tracks, so a mock run exercises all of the scoreboards at once.
+ */
+const GAMES: MockGame[] = [
+  { name: 'Wordle', score: guesses_out_of(6, 0.08) },
+  { name: 'Connections', score: () => String(between(0, 4)) },
+  { name: 'The Mini', score: () => String(between(28, 400)) },
+  {
+    name: 'Strands',
+    score: () => {
+      const hints = between(0, 4);
+      return `${hints},${8 - hints},8`;
+    },
+  },
+  {
+    name: '🌱 Bullpen',
+    score: () =>
+      one_of(String(between(20, 400)), `${between(1, 9)}.${between(0, 9)}s`),
+    day_id: iso_date,
+  },
+  {
+    name: '🔥 Bullpen',
+    score: () => String(between(45, 900)),
+    day_id: iso_date,
+  },
+  { name: 'Tvers', score: () => String(between(40, 600)), day_id: iso_date },
+  { name: 'Former', score: () => String(between(4, 40)), day_id: iso_date },
+  { name: 'Globle', score: () => String(between(1, 20)) },
+  { name: 'GlobleCapitals', score: () => String(between(1, 25)) },
+  { name: 'Gamedle (Classic)', score: () => String(between(1, 6)) },
+  { name: 'Gamedle (Artwork)', score: () => String(between(1, 6)) },
+  { name: 'Gamedle (Keywords)', score: () => String(between(1, 6)) },
+  { name: 'Gamedle (Guess)', score: () => String(between(1, 10)) },
+  { name: 'FoodGuessr', score: () => String(between(3, 10)) },
+  {
+    name: 'TimeGuessr',
+    score: () => between(12_000, 49_500).toLocaleString('en-GB'),
+  },
+  { name: 'Bybandle', score: guesses_out_of(5, 0.15), day_id: iso_date },
+  {
+    name: '4x3',
+    score: () =>
+      one_of(
+        `${between(60, 160)},${between(0, 3)}`,
+        `${between(60, 160)},0`,
+        `X,${between(1, 4)}`,
+        `-100,RULE BREAKER`,
+      ),
+    day_id: iso_date,
+  },
+];
+
+/**
+ * Puzzle numbers to count up from, for the games that identify a day by one.
+ */
+const BASE_DAY_IDS: Record<string, number> = {
+  Wordle: 1351,
+  Connections: 629,
+  'The Mini': 2025,
+  Strands: 363,
+  Globle: 1351,
+  GlobleCapitals: 629,
+  TimeGuessr: 1075,
+};
 
 export async function generate_mock_data() {
-    // First, let's analyze existing data patterns
-    const existingEntries = await GameEntryModel.find({}).exec();
-    
-    // Get active users from the last month
-    const activeUsers = await GameEntryModel.distinct('user', {
-        createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) }
-    });
-    
-    // Take 5 random active users or create mock users if none exist
-    const selectedUsers = activeUsers.length > 0 
-        ? activeUsers.sort(() => 0.5 - Math.random()).slice(0, 5)
-        : Array.from({ length: 5 }, (_, i) => ({
-            id: crypto.randomUUID() as Snowflake,
-            name: `TestUser${i + 1}`,
-            server_name: `User${i + 1}`
+  const existingEntries = await GameEntryModel.find({}).exec();
+
+  // Get active users from the last month
+  const activeUsers = await GameEntryModel.distinct('user', {
+    createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) },
+  });
+
+  // Take 5 random active users or create mock users if none exist
+  const selectedUsers =
+    activeUsers.length > 0
+      ? activeUsers.sort(() => 0.5 - Math.random()).slice(0, 5)
+      : Array.from({ length: 5 }, (_, i) => ({
+          id: snowflake(),
+          name: `TestUser${i + 1}`,
+          server_name: `User${i + 1}`,
         }));
 
-    const games = [
-        "Wordle",
-        "Connections",
-        "The Mini",
-        "Strands",
-        "Globle",
-        "GlobleCapitals"
-    ] as const;
+  const entries: DbEntry[] = [];
+  const today = new Date();
 
-    const entries: DbEntry[] = [];
-    const today = new Date();
+  for (let dayOffset = DAYS - 1; dayOffset >= 0; dayOffset--) {
+    const currentDate = new Date(today);
+    currentDate.setDate(currentDate.getDate() - dayOffset);
 
-    // Generate entries for the last 7 days
-    for (let dayOffset = 6; dayOffset >= 0; dayOffset--) {
-        const currentDate = new Date(today);
-        currentDate.setDate(currentDate.getDate() - dayOffset);
-        
-        for (const user of selectedUsers) {
-            // Generate entries for each game type with a 90% participation rate
-            for (const game of games) {
-                if (Math.random() > 0.9) continue; // 90% participation rate
+    for (const user of selectedUsers) {
+      for (const game of GAMES) {
+        if (Math.random() < SKIP_RATE) continue;
 
-                const dayId = calculateDayId(game, currentDate);
-                const score = generateScore(game);
-                const content = generateContent(game, dayId, score);
+        const day_id =
+          game.day_id?.(currentDate) ?? calculateDayId(game.name, currentDate);
+        const score = game.score();
 
-                const entry: DbEntry = {
-                    game,
-                    day_id: dayId.toString(),
-                    score,
-                    user: {
-                        id: user.id,
-                        name: user.name,
-                        server_name: user.server_name
-                    },
-                    message_id: crypto.randomUUID() as Snowflake, // This is fine as randomUUID() exists in both Web and Node Crypto
-                    channel_id: existingEntries[0]?.channel_id || "1335589483705532429" as Snowflake,
-                    server_id: existingEntries[0]?.server_id || "1313917326013235251" as Snowflake,
-                    content,
-                    schema_version: "2",
-                    createdAt: currentDate,
-                    updatedAt: currentDate
-                };
-
-                entries.push(entry);
-            }
-        }
+        entries.push({
+          game: game.name,
+          day_id: String(day_id),
+          score,
+          user: {
+            id: user.id,
+            name: user.name,
+            server_name: user.server_name,
+          },
+          message_id: snowflake(),
+          channel_id:
+            existingEntries[0]?.channel_id ||
+            ('1335589483705532429' as Snowflake),
+          server_id:
+            existingEntries[0]?.server_id ||
+            ('1313917326013235251' as Snowflake),
+          content: generateContent(game.name, day_id, score),
+          // version -1 = mock data
+          schema_version: '-1',
+          createdAt: currentDate,
+          updatedAt: currentDate,
+        });
+      }
     }
-    entries.forEach(e => {
-      e.schema_version = "-1"; // version -1 = mock data
-    })
+  }
 
-    const enable_dev_features = process.argv.includes('--dev')
-    if (enable_dev_features) {
-        const mockEntries = entries as GameEntry[];
-        await GameEntryModel.insertMany(mockEntries)
-    }
-    return `Created ${entries.length} realistic mock entries. ${enable_dev_features 
-    ? 'Added directly to db since the bot is running in dev mode, and should be running an in-memory database.'
-    : ''}`;
+  const enable_dev_features = process.argv.includes('--dev');
+  if (enable_dev_features) {
+    await GameEntryModel.insertMany(entries as GameEntry[]);
+  }
+
+  return `Created ${entries.length} realistic mock entries across ${GAMES.length} games. ${
+    enable_dev_features
+      ? 'Added directly to db since the bot is running in dev mode, and should be running an in-memory database.'
+      : ''
+  }`;
 }
 
-function calculateDayId(game: string, date: Date): number {
-    const baseIds: Record<string, number> = {
-        "Wordle": 1351,
-        "Connections": 629,
-        "The Mini": 2025,
-        "Strands": 363,
-        "Globle": 1351,
-        "GlobleCapitals": 629
-    };
+function calculateDayId(game: string, date: Date): number | string {
+  const base = BASE_DAY_IDS[game];
+  if (base === undefined) {
+    return iso_date(date);
+  }
 
-    const daysSinceBase = Math.floor((date.getTime() - new Date('2024-01-01').getTime()) / (1000 * 60 * 60 * 24));
-    return (baseIds[game] || 1) + daysSinceBase;
+  const daysSinceBase = Math.floor(
+    (date.getTime() - new Date('2024-01-01').getTime()) / (1000 * 60 * 60 * 24),
+  );
+  return base + daysSinceBase;
 }
 
-function generateScore(game: string): string {
-    switch (game) {
-        case "Wordle":
-            return `${Math.floor(Math.random() * 6) + 1}/6`;
-        case "Connections":
-            return `${Math.floor(Math.random() * 4)}`;
-        case "The Mini":
-            return `${Math.floor(Math.random() * 200) + 50}`;
-        case "Strands":
-            const attempts = Math.floor(Math.random() * 8);
-            const correct = Math.floor(Math.random() * 8);
-            const total = 8;
-            return `${attempts},${correct},${total}`;
-        case "Globle":
-        case "GlobleCapitals":
-            return `${Math.floor(Math.random() * 20) + 3}`;
-        default:
-            return "0";
-    }
+function generateContent(
+  game: string,
+  dayId: number | string,
+  score: string,
+): string {
+  switch (game) {
+    case 'Wordle':
+      return generateWordleContent(dayId, score);
+    case 'Connections':
+      return generateConnectionsContent(dayId, score);
+    case 'The Mini':
+      return `https://www.nytimes.com/badges/games/mini.html?d=${dayId}&t=${score}&c=${crypto.randomBytes(16).toString('hex')}&smid=url-share`;
+    case 'Globle':
+    case 'GlobleCapitals':
+      return `🌎 ${dayId} 🌍\n🔥 ${score} | Avg. Guesses: ${Math.floor(Number(score) * 1.5)}\n🟥🟩🟦 = ${score}\n\nhttps://globle-game.com\n#globle`;
+    default:
+      return `${game} ${dayId}\n${score}`;
+  }
 }
 
-// Then replace the crypto.randomBytes usage in generateContent:
-function generateContent(game: string, dayId: number, score: string): string {
-    switch (game) {
-        case "Wordle":
-            return generateWordleContent(dayId, score);
-        case "Connections":
-            return generateConnectionsContent(dayId, score);
-        case "The Mini":
-            // Fix the crypto.randomBytes usage:
-            return `https://www.nytimes.com/badges/games/mini.html?d=${dayId}&t=${score}&c=${crypto.randomBytes(16).toString('hex')}&smid=url-share`;
-        case "Globle":
-        case "GlobleCapitals":
-            return `🌎 ${dayId} 🌍\n🔥 ${score} | Avg. Guesses: ${Math.floor(Number(score) * 1.5)}\n🟥🟩🟦 = ${score}\n\nhttps://globle-game.com\n#globle`;
-        default:
-            return `${game} ${dayId}\n${score}`;
-    }
+function generateWordleContent(dayId: number | string, score: string): string {
+  const patterns = [
+    '⬛🟨⬛🟩⬛',
+    '🟨🟨⬛⬛🟨',
+    '🟩🟨🟨🟨⬛',
+    '🟩🟩⬛🟩🟩',
+    '🟩🟩🟩🟩🟩',
+  ];
+
+  const attempts = parseInt(score) || 6;
+  const grid = patterns.slice(0, attempts).join('\n');
+
+  return `Wordle ${dayId} ${score}\n\n${grid}`;
 }
 
-function generateWordleContent(dayId: number, score: string): string {
-    const patterns = [
-        "⬛🟨⬛🟩⬛",
-        "🟨🟨⬛⬛🟨",
-        "🟩🟨🟨🟨⬛",
-        "🟩🟩⬛🟩🟩",
-        "🟩🟩🟩🟩🟩"
-    ];
+function generateConnectionsContent(
+  dayId: number | string,
+  score: string,
+): string {
+  const colors = ['🟪', '🟦', '🟨', '🟩'];
+  const attempts = Math.min(Number(score), 4);
+  let content = `Connections\nPuzzle ${dayId}\n`;
 
-    const attempts = parseInt(score) || 6;
-    const grid = patterns
-        .slice(0, attempts)
-        .join('\n');
+  for (let i = 0; i < attempts; i++) {
+    content +=
+      shuffle([...colors])
+        .slice(0, 4)
+        .join('') + '\n';
+  }
 
-    return `Wordle ${dayId} ${score}\n\n${grid}`;
-}
-
-function generateConnectionsContent(dayId: number, score: string): string {
-    const colors = ['🟪', '🟦', '🟨', '🟩'];
-    const attempts = Math.min(Number(score), 4);
-    let content = `Connections\nPuzzle ${dayId}\n`;
-    
-    for (let i = 0; i < attempts; i++) {
-        content += shuffle([...colors]).slice(0, 4).join('') + '\n';
-    }
-    
-    return content;
+  return content;
 }
 
 function shuffle<T>(array: T[]): T[] {
-    return array.sort(() => Math.random() - 0.5);
+  return array.sort(() => Math.random() - 0.5);
 }

--- a/src/test/scoreboard.test.ts
+++ b/src/test/scoreboard.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  highest_first,
+  lowest_first,
+  numeric,
+  render_heading,
+  render_rows,
+} from '../core/embeds/scoreboard.js';
+import { Scoreboard } from '../core/embeds/embed_formatter.js';
+import { GameEntry } from '../core/database/schema.js';
+
+const entry = (score: string, name: string = 'Player'): GameEntry => ({
+  game: 'Test',
+  day_id: '1',
+  score,
+  user: { id: `id-${name}`, name },
+  message_id: '1234567890123456789',
+  channel_id: '1234567890123456780',
+  server_id: '1234567890123456781',
+  schema_version: '2',
+});
+
+describe('numeric', () => {
+  test('reads plain and fraction scores', () => {
+    expect(numeric('3')).toBe(3);
+    expect(numeric('3/6')).toBe(3);
+    expect(numeric('X/6')).toBeNaN();
+  });
+
+  test('reads a thousands separator as one number', () => {
+    expect(numeric('44,123')).toBe(44123);
+  });
+
+  test('does not merge list-shaped scores', () => {
+    expect(numeric('0,8,8')).toBe(0); // Strands: hints first
+    expect(numeric('120,2')).toBe(120); // 4x3: points first
+    expect(numeric('-100,RULE BREAKER')).toBe(-100);
+  });
+});
+
+describe('sorters', () => {
+  test('lowest_first ranks ascending with unreadable scores last', () => {
+    const sorted = [entry('X/6'), entry('4/6'), entry('1/6')].sort(
+      lowest_first(),
+    );
+    expect(sorted.map((e) => e.score)).toEqual(['1/6', '4/6', 'X/6']);
+  });
+
+  test('highest_first ranks descending with unreadable scores last', () => {
+    const sorted = [entry('X,2'), entry('120,0'), entry('157,1')].sort(
+      highest_first(),
+    );
+    expect(sorted.map((e) => e.score)).toEqual(['157,1', '120,0', 'X,2']);
+  });
+});
+
+describe('render_heading', () => {
+  test('joins title and unit', () => {
+    expect(render_heading({ title: 'Wordle', unit: 'guesses' }, 'x')).toBe(
+      'Wordle · guesses',
+    );
+  });
+
+  test('falls back to the stored name without a title', () => {
+    expect(render_heading({}, 'GlobleCapitals')).toBe('GlobleCapitals');
+  });
+});
+
+describe('render_rows', () => {
+  test('awards medals by rank, sharing rank on ties', () => {
+    const rows = render_rows(
+      [entry('1/6', 'A'), entry('1/6', 'B'), entry('3/6', 'C')],
+      {},
+    );
+    expect(rows[0]).toContain('🥇');
+    expect(rows[1]).toContain('🥇');
+    expect(rows[2]).toContain('🥉');
+  });
+
+  test('numbers ranks past the medals', () => {
+    const rows = render_rows(
+      ['1', '2', '3', '4'].map((s, i) => entry(s, `P${i}`)),
+      {},
+    );
+    expect(rows[3]).toContain('`4.`');
+  });
+
+  test('failed entries get a skull and never a medal', () => {
+    const rows = render_rows([entry('X/6', 'A')], {
+      is_failed: (score) => score.startsWith('X'),
+    });
+    expect(rows[0]).toContain('💀');
+    expect(rows[0]).not.toContain('🥇');
+    expect(rows[0]).toContain('`1.`');
+  });
+
+  test('perfect entries get a sparkle', () => {
+    const rows = render_rows([entry('1/6', 'A')], {
+      is_perfect: (score) => score.startsWith('1/'),
+    });
+    expect(rows[0]).toContain('✨');
+  });
+
+  test('pads scores to a column and links the player name', () => {
+    const rows = render_rows([entry('9', 'A'), entry('15', 'B')], {});
+    expect(rows[0]).toContain('` 9`');
+    expect(rows[1]).toContain('`15`');
+    expect(rows[0]).toContain('[A](https://discord.com/channels/');
+  });
+
+  test('renders through the display function', () => {
+    const rows = render_rows([entry('83', 'A')], {
+      display: (score) => `${score}s`,
+    });
+    expect(rows[0]).toContain('`83s`');
+  });
+});
+
+describe('Scoreboard.render', () => {
+  const board = (entries: GameEntry[], max_entries: number = 10) =>
+    new Scoreboard('Test · unit', {}, entries, max_entries);
+
+  test('summarizes entries past the row cap as an italic more-line', () => {
+    const entries = Array.from({ length: 12 }, (_, i) =>
+      entry(String(i + 1), `Player${i}`),
+    );
+    const rendered = board(entries).render(true);
+
+    expect(rendered).not.toBeNull();
+    const lines = rendered!.field.value.split('\n');
+    const more = lines[lines.length - 1].match(/^\*\+ (\d+) more\*$/);
+
+    // Rows shown plus the more-line remainder must account for every entry.
+    expect(more).not.toBeNull();
+    expect(lines.length - 1 + Number(more![1])).toBe(12);
+    // Subtext does not render inside embed fields, so the more-line must never use it.
+    expect(rendered!.field.value).not.toContain('-#');
+  });
+
+  test('trims rows that do not fit the field limit, keeping the top', () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      entry(String(i + 1), `Player${i}-${'x'.repeat(100)}`),
+    );
+    const rendered = board(entries).render(true);
+
+    expect(rendered).not.toBeNull();
+    expect(rendered!.field.value.length).toBeLessThanOrEqual(1024);
+    expect(rendered!.field.value).toContain('Player0');
+    expect(rendered!.field.value).toMatch(/\*\+ \d+ more\*$/);
+    expect(rendered!.entries).toBe(10);
+  });
+
+  test('counts each player once', () => {
+    const rendered = board([entry('1', 'A'), entry('2', 'A')]).render(true);
+    expect(rendered!.players).toEqual(['id-A']);
+  });
+});

--- a/src/test/summary.test.ts
+++ b/src/test/summary.test.ts
@@ -1,0 +1,234 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from '@jest/globals';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { GameSummaryMessage } from '../core/embeds/embed_structure.js';
+import {
+  GameEntryModel,
+  SummaryMessageModel,
+} from '../core/database/schema.js';
+import { GameBuilder } from '../core/builders/game_builder.js';
+import { MatchType } from '../core/message_parser.js';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 60_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await GameEntryModel.deleteMany({});
+  await SummaryMessageModel.deleteMany({});
+});
+
+/** A minimal game whose parser name matches `name`, so seeded entries are found. */
+const game = (name: string) =>
+  new GameBuilder(name)
+    .set_matcher(/^$/, [MatchType.Day, MatchType.Score])
+    .build();
+
+/** A summary of `n` single-game collections, enough alike to app.ts to exercise the same paths. */
+const summary_of = (n: number) =>
+  new GameSummaryMessage({
+    content: 'header',
+    empty: 'nothing yet',
+    embeds: Array.from({ length: n }, (_, i) => ({
+      title: `Collection ${i}`,
+      description: `Games in collection ${i}`,
+      fields: [{ game: game(`Game${i}`), inline: true }],
+    })),
+  });
+
+const seed = (game: string, user: string, days_ago: number = 0) => {
+  const at = new Date();
+  at.setDate(at.getDate() - days_ago);
+  return {
+    game,
+    day_id: '1',
+    score: '3',
+    user: {
+      id: `id-${user}`,
+      name: user,
+      server_name: `${user}-${'n'.repeat(40)}`,
+    },
+    message_id: '1234567890123456789',
+    channel_id: '1234567890123456780',
+    server_id: '1234567890123456781',
+    schema_version: '2',
+    createdAt: at,
+    updatedAt: at,
+  };
+};
+
+const build = (summary: GameSummaryMessage) =>
+  (summary as any).build_messages() as Promise<any[][]>;
+
+const embed_length = (e: any): number =>
+  (e.title?.length ?? 0) +
+  (e.description?.length ?? 0) +
+  (e.footer?.text.length ?? 0) +
+  (e.fields ?? []).reduce(
+    (t: number, f: any) => t + f.name.length + f.value.length,
+    0,
+  );
+
+describe('build_messages', () => {
+  test('shows nothing when nobody played', async () => {
+    expect(await build(summary_of(3))).toEqual([]);
+  });
+
+  test("only shows games played today, not yesterday's", async () => {
+    await GameEntryModel.insertMany([
+      seed('Game0', 'A'),
+      seed('Game1', 'B', 1),
+      seed('Game2', 'C', 1),
+    ]);
+
+    const messages = await build(summary_of(3));
+    const embeds = messages.flat();
+
+    expect(embeds).toHaveLength(1);
+    expect(embeds[0].title).toBe('Collection 0');
+  });
+
+  test('fits a quiet day in a single message', async () => {
+    await GameEntryModel.insertMany([seed('Game0', 'A'), seed('Game1', 'B')]);
+
+    expect(await build(summary_of(3))).toHaveLength(1);
+  });
+
+  test('splits a busy day across messages without dropping a played game', async () => {
+    const users = Array.from({ length: 10 }, (_, u) => `User${u}`);
+    await GameEntryModel.insertMany(
+      Array.from({ length: 9 }, (_, i) =>
+        users.map((user) => seed(`Game${i}`, user)),
+      ).flat(),
+    );
+
+    const messages = await build(summary_of(9));
+    const embeds = messages.flat();
+
+    expect(messages.length).toBeGreaterThan(1);
+    expect(embeds).toHaveLength(9);
+    for (const message of messages) {
+      expect(message.length).toBeLessThanOrEqual(10);
+      expect(
+        message.reduce((total, embed) => total + embed_length(embed), 0),
+      ).toBeLessThanOrEqual(6000);
+    }
+  });
+
+  test('footers count players and entries', async () => {
+    await GameEntryModel.insertMany([
+      seed('Game0', 'A'),
+      { ...seed('Game0', 'B'), day_id: '2' },
+    ]);
+
+    const [embeds] = await build(summary_of(1));
+    expect(embeds[0].footer.text).toBe('2 players · 2 entries');
+  });
+});
+
+describe('send', () => {
+  /**
+   * A stand-in for a ButtonInteraction: posts get incrementing IDs, deletions are recorded, and
+   * `failing_follow_ups` makes followUp throw.
+   */
+  const stub_interaction = (deleted: string[], failing_follow_ups = false) => {
+    let next_id = 0;
+    return {
+      channelId: 'channel-1',
+      user: { username: 'tester' },
+      member: null,
+      deferReply: async () => {},
+      editReply: async () => ({ id: `msg-${next_id++}` }),
+      followUp: async () => {
+        if (failing_follow_ups) throw new Error('rate limited');
+        return { id: `msg-${next_id++}` };
+      },
+      channel: {
+        messages: {
+          fetch: async (id: string) => ({
+            delete: async () => {
+              deleted.push(id);
+            },
+          }),
+        },
+      },
+    } as any;
+  };
+
+  const seed_split_day = async () => {
+    const users = Array.from({ length: 10 }, (_, u) => `User${u}`);
+    await GameEntryModel.insertMany(
+      Array.from({ length: 9 }, (_, i) =>
+        users.map((user) => seed(`Game${i}`, user)),
+      ).flat(),
+    );
+  };
+
+  test('replacing a summary deletes every message of the previous one', async () => {
+    await seed_split_day();
+    const summary = summary_of(9);
+    const deleted: string[] = [];
+
+    await summary.send(stub_interaction(deleted));
+    const first = await SummaryMessageModel.findOne({
+      channel_id: 'channel-1',
+    });
+    expect(first!.message_ids.length).toBeGreaterThan(1);
+    expect(deleted).toEqual([]);
+
+    await summary.send(stub_interaction(deleted));
+    expect(deleted.sort()).toEqual([...first!.message_ids].sort());
+  });
+
+  test('tracks what was posted even when a follow-up fails', async () => {
+    await seed_split_day();
+    const summary = summary_of(9);
+    const deleted: string[] = [];
+
+    await expect(summary.send(stub_interaction(deleted, true))).rejects.toThrow(
+      'rate limited',
+    );
+
+    // The reply went out before the follow-up failed; it must be on record so the next summary
+    // cleans it up rather than leaving it orphaned in the channel.
+    const tracked = await SummaryMessageModel.findOne({
+      channel_id: 'channel-1',
+    });
+    expect(tracked!.message_ids).toEqual(['msg-0']);
+
+    await summary.send(stub_interaction(deleted));
+    expect(deleted).toContain('msg-0');
+  });
+
+  test('still cleans up a summary tracked by the single-message schema', async () => {
+    await GameEntryModel.insertMany([seed('Game0', 'A')]);
+    await SummaryMessageModel.create({
+      channel_id: 'channel-1',
+      message_id: 'legacy-1',
+    });
+    const deleted: string[] = [];
+
+    await summary_of(1).send(stub_interaction(deleted));
+
+    expect(deleted).toEqual(['legacy-1']);
+    const row = await SummaryMessageModel.findOne({
+      channel_id: 'channel-1',
+    }).lean();
+    expect((row as any).message_id).toBeUndefined();
+  });
+});

--- a/src/test/ut.test.ts
+++ b/src/test/ut.test.ts
@@ -1,7 +1,0 @@
-import { describe, test, expect, jest } from '@jest/globals';
-
-describe('test', () => {
-    test('test', async () => {
-        expect(null).toBeNull();
-    });
-});

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,10 +10,8 @@ export function seconds_to_display_time(seconds: number | string): string {
 }
 
 /**
- * Formats a duration in seconds as a clock, e.g. `83` as `1:23`.
- *
- * Preferred over `seconds_to_display_time` on scoreboards, where solve times sit in a column: two
- * times of the same magnitude are always the same width here, where `1m23s` and `2m3s` are not.
+ * Formats a duration in seconds as a clock, e.g. `83` as `1:23`. Preferred over
+ * `seconds_to_display_time` in a column, where `1m23s` and `2m3s` would not line up.
  */
 export function seconds_to_clock(seconds: number | string): string {
   const total = Math.floor(Number(seconds));

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,24 @@ export function seconds_to_display_time(seconds: number | string): string {
   );
 }
 
+/**
+ * Formats a duration in seconds as a clock, e.g. `83` as `1:23`.
+ *
+ * Preferred over `seconds_to_display_time` on scoreboards, where solve times sit in a column: two
+ * times of the same magnitude are always the same width here, where `1m23s` and `2m3s` are not.
+ */
+export function seconds_to_clock(seconds: number | string): string {
+  const total = Math.floor(Number(seconds));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+
+  return [
+    ...(h > 0 ? [String(h), String(m).padStart(2, '0')] : [String(m)]),
+    String(s).padStart(2, '0'),
+  ].join(':');
+}
+
 export function get_today(): Date {
   const now = new Date();
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());


### PR DESCRIPTION
Reworks the summary embeds into proper scoreboards: medals, ties sharing a rank, and scores padded into a monospace column. Each game now declares how its score should read, so `Tvers · points` and `Former · moves` are no longer both a bare number.

```
Wordle · guesses          Connections · mistakes
🥇 `1/6` Jørgen ✨         🥇 `1` Peter
🥇 `1/6` Peter ✨          🥈 `2` Jørgen
🥉 `3/6` Jakob            `4.` `4` Ola 💀
```

Also fixes three bugs found on the way:

- **Bullpen never showed up.** Entries save under the message parser's name (`🌱 Bullpen`) but the summary looked them up by the builder's name (`BullpenEasy`), so it always found zero.
- **Tvers, FoodGuessr and TimeGuessr sorted ascending**, putting the winner last. TimeGuessr also sorted `44,123` as `44`.
- **The summary could exceed Discord's 6000 character embed limit** and be rejected outright — 18 games of jump links is well past it.

## Splitting

Rather than shrink scoreboards to fit, a summary too big for one message continues into follow-up messages, as many as it takes. Collections are rendered whole and packed into messages, filling each up to Discord's limits before opening the next, so a day that fits in one message still gets exactly one:

| players (18 games) | messages | chars | jump links |
|---|---|---|---|
| 5 | 2 | 10750 | kept |
| 10 | 5 | 18628 | kept |
| 40 | 5 | 18787 | kept |
| 80 | 5 | 18762 | kept |

Message count plateaus because each scoreboard still caps at 10 rows with `+ N more`.

Because a summary can now be several messages, `SummaryMessage` tracks every message ID and replacing a summary deletes all of them. The old single-ID field is kept read-only so rows written by the currently deployed version still get cleaned up rather than orphaning a message.

## Also

Per-collection embed colours, a `N players · M entries` footer, and the mock data generator extended to all 18 games with `[mock]`-prefixed users.

## Verified

Against seeded data and the running bot: games played only yesterday produce no scoreboard; all 18 games played today render all 18 boards; every message stays inside Discord's limits at every density tested; no played game is ever dropped. Confirmed in Discord that a summary posts across multiple messages and that pressing the button again replaces every message of the previous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)