### PR TITLE
feat(bybandle): accept the Norwegian dd.MM.yyyy share date

### DIFF
--- a/src/games/bybandle.ts
+++ b/src/games/bybandle.ts
@@ -2,10 +2,16 @@ import { GameBuilder } from '../core/builders/game_builder.js';
 import { MatchType } from '../core/message_parser.js';
 
 export const Bybandle = new GameBuilder('Bybandle')
-  .set_matcher(/Bybandle (\d{4}-\d{2}-\d{2}) ([\dX]\/\d)/, [
+  .set_matcher(/Bybandle (\d{4}-\d{2}-\d{2}|\d{2}\.\d{2}\.\d{4}) ([\dX]\/\d)/, [
     MatchType.Day,
     MatchType.Score,
   ])
+  // Bybandle switched its share text from 2026-06-07 to 07.06.2026; store
+  // both as ISO so day ids stay comparable across the switch.
+  .set_day_id_parser((day) => {
+    const [d, m, y] = day.split('.');
+    return y ? `${y}-${m}-${d}` : day;
+  })
   .set_scoreboard({
     unit: 'guesses',
     is_perfect: (score) => score.startsWith('1/'),

--- a/src/test/bybandle.test.ts
+++ b/src/test/bybandle.test.ts
@@ -1,0 +1,69 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from '@jest/globals';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { Message } from 'discord.js';
+import { GameEntryModel } from '../core/database/schema.js';
+import { Bybandle } from '../games/bybandle.js';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 60_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await GameEntryModel.deleteMany({});
+});
+
+/** A minimal Discord message carrying `content`, with replies swallowed. */
+const message = (content: string) =>
+  ({
+    content,
+    id: '1234567890123456789',
+    guildId: '1234567890123456781',
+    author: { id: 'user-1', displayName: 'Player' },
+    member: { displayName: 'Player' },
+    channel: { id: '1234567890123456780', send: async () => undefined },
+  }) as unknown as Message;
+
+describe('Bybandle share text', () => {
+  test('parses the original ISO date format', async () => {
+    const entry = await Bybandle.handle_message(
+      message('Bybandle 2026-06-07 2/3\n🟠—🟢—⚪'),
+    );
+
+    expect(entry?.day_id).toBe('2026-06-07');
+    expect(entry?.score).toBe('2/3');
+  });
+
+  test('parses the Norwegian date format and stores the day id as ISO', async () => {
+    const entry = await Bybandle.handle_message(
+      message('Bybandle 07.06.2026 2/3\n🟠—🟢—⚪'),
+    );
+
+    expect(entry?.day_id).toBe('2026-06-07');
+    expect(entry?.score).toBe('2/3');
+  });
+
+  test('parses a loss in the Norwegian date format', async () => {
+    const entry = await Bybandle.handle_message(
+      message('Bybandle 07.06.2026 X/3\n🟠—🟠—🟠'),
+    );
+
+    expect(entry?.day_id).toBe('2026-06-07');
+    expect(entry?.score).toBe('X/3');
+  });
+});


### PR DESCRIPTION
Bybandle is switching its share text date from ISO (`Bybandle 2026-06-07 2/3`) to the Norwegian format (`Bybandle 07.06.2026 2/3`), because iOS's data detector reads the ISO date followed by the score as a phone number when the result is pasted.

## Changes

- The matcher now accepts both `yyyy-MM-dd` and `dd.MM.yyyy`.
- A `day_id_parser` normalizes the Norwegian format back to ISO before storage, so day ids stay comparable with historical entries and responses/scoreboards group correctly across the switch.
- Added tests covering both formats (win and loss) through `handle_message`, using the same in-memory Mongo setup as the summary tests.

All 27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)